### PR TITLE
feat(cart) : order에 배송비 부분 추가

### DIFF
--- a/docs/erd/dbdiagram-io.md
+++ b/docs/erd/dbdiagram-io.md
@@ -163,6 +163,7 @@ Table "orders" {
   "order_number" varchar(20) [unique, not null, note: '주문 번호(ORD + yyyyMMdd + 난수 9자리)']
   "user_id" bigint [not null, note: '회원 아이디']
   "total_amount" integer [not null, note: '총 주문 금액']
+  "delivery_amount" integer [not null, note: '배달비']
   "recipient_name" varchar(100) [not null, note: '받는사람 이름']
   "recipient_phone" varchar(20) [not null, note: '받는사람 연락처']
   "zip_code" varchar(10) [not null, note: '배송지 우편번호']


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

장바구니 배송비 부분을 위한 order 테이블 배송비 컬럼 추가
---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

ddl 수정 : order 테이블에 delivery_price 컬럼 추가
---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

장바구니에 배송비 부분을 보여주게 되면서 cart 테이블을 새로 생성하여 배송비를 출력하는 것보다  배송비 부분 policy를 따로 만드는 방식으로 구현하기로 결정하였습니다.
그에 따라 Order 테이블에 배송비 금액을 저장하는 column이 필요해져 Ddl 구조에서 해당 컬럼을 추가하였습니다.
---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->