### PR TITLE
[feat] 상품 수정/삭제 API 추가

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.admin.product.application
 
 import com.fastcampus.commerce.admin.product.application.request.RegisterProductRequest
+import com.fastcampus.commerce.admin.product.application.request.UpdateProductRequest
 import com.fastcampus.commerce.admin.product.application.response.SellingStatusResponse
 import com.fastcampus.commerce.common.error.CommonErrorCode
 import com.fastcampus.commerce.common.error.CoreException
@@ -31,5 +32,20 @@ class AdminProductService(
             fileCommandService.markFilesAsSuccess(request.files)
             register
         } ?: throw CoreException(CommonErrorCode.SERVER_ERROR)
+    }
+
+    fun update(adminId: Long, request: UpdateProductRequest) {
+        // TODO:
+        //  이미지가 바뀌지 않은 경우 불필요한 요청. 시간이 없어 그대로 진행.
+        //  이미지만 변경하는 PATCH를 만들던가,
+        //  product를 조회한 후 url이 변경되었는지 확인 후 요청하도록 수정
+        //  현재 markFilesAsSuccess는 멱등성있게 작성되어있어 문제 없음.
+        uploadedFileVerifier.verifyFileWithS3Urls(request.files)
+        val command = request.toCommand(adminId)
+        transactionTemplate.execute {
+            productCommandService.updateProduct(command)
+            fileCommandService.markFilesAsSuccess(request.files)
+            productCommandService.updateInventory(command)
+        }
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
@@ -48,4 +48,15 @@ class AdminProductService(
             productCommandService.updateInventory(command)
         }
     }
+
+    fun delete(adminId: Long, productId: Long) {
+        // TODO:
+        //  FileMetadata 삭제
+        //  이를 위해서는 File <-> Domain 매핑하는 매핑 테이블을 만들고,
+        //  fileCommandService.markFilesAsSuccess 에서 매핑테이블에 넣어야함.
+        //  작업량이 많을 것으로 예상되어 우선 상품 삭제기능만 추가.
+        transactionTemplate.execute {
+            productCommandService.deleteProduct(productId)
+        }
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/RegisterProductRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/RegisterProductRequest.kt
@@ -1,6 +1,6 @@
 package com.fastcampus.commerce.admin.product.application.request
 
-import com.fastcampus.commerce.product.domain.service.dto.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductRegister
 
 data class RegisterProductRequest(
     val name: String,

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/UpdateProductRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/UpdateProductRequest.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.commerce.admin.product.application.request
+
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import com.fastcampus.commerce.product.domain.model.ProductUpdater
+
+data class UpdateProductRequest(
+    val id: Long,
+    val name: String,
+    val price: Int,
+    val quantity: Int,
+    val thumbnail: String,
+    val detailImage: String,
+    val intensityId: Long,
+    val cupSizeId: Long,
+    val status: SellingStatus,
+) {
+    val categoryIds get() = listOf(intensityId, cupSizeId)
+    val files get() = listOf(detailImage, thumbnail)
+
+    fun toCommand(registerId: Long): ProductUpdater =
+        ProductUpdater(
+            id = id,
+            name = name,
+            price = price,
+            quantity = quantity,
+            thumbnail = thumbnail,
+            detailImage = detailImage,
+            categoryIds = categoryIds,
+            status = status,
+            updaterId = registerId,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/UpdateProductRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/UpdateProductRequest.kt
@@ -17,7 +17,7 @@ data class UpdateProductRequest(
     val categoryIds get() = listOf(intensityId, cupSizeId)
     val files get() = listOf(detailImage, thumbnail)
 
-    fun toCommand(registerId: Long): ProductUpdater =
+    fun toCommand(updaterId: Long): ProductUpdater =
         ProductUpdater(
             id = id,
             name = name,

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
@@ -2,10 +2,14 @@ package com.fastcampus.commerce.admin.product.interfaces
 
 import com.fastcampus.commerce.admin.product.application.AdminProductService
 import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
+import com.fastcampus.commerce.admin.product.interfaces.request.UpdateProductApiRequest
 import com.fastcampus.commerce.admin.product.interfaces.response.RegisterProductApiResponse
+import com.fastcampus.commerce.admin.product.interfaces.response.UpdateProductApiResponse
 import com.fastcampus.commerce.common.response.EnumResponse
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -29,5 +33,15 @@ class AdminProductController(
         val adminId = 1L
         val productId: Long = adminProductService.register(adminId, request.toServiceRequest())
         return RegisterProductApiResponse(productId)
+    }
+
+    @PutMapping("/{productId}")
+    fun updateProduct(
+        @PathVariable productId: Long,
+        @RequestBody request: UpdateProductApiRequest,
+    ): UpdateProductApiResponse {
+        val adminId = 1L
+        adminProductService.update(adminId, request.toServiceRequest(productId))
+        return UpdateProductApiResponse(productId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
@@ -3,9 +3,11 @@ package com.fastcampus.commerce.admin.product.interfaces
 import com.fastcampus.commerce.admin.product.application.AdminProductService
 import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
 import com.fastcampus.commerce.admin.product.interfaces.request.UpdateProductApiRequest
+import com.fastcampus.commerce.admin.product.interfaces.response.DeleteProductApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.RegisterProductApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.UpdateProductApiResponse
 import com.fastcampus.commerce.common.response.EnumResponse
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -43,5 +45,14 @@ class AdminProductController(
         val adminId = 1L
         adminProductService.update(adminId, request.toServiceRequest(productId))
         return UpdateProductApiResponse(productId)
+    }
+
+    @DeleteMapping("/{productId}")
+    fun deleteProduct(
+        @PathVariable productId: Long,
+    ): DeleteProductApiResponse {
+        val adminId = 1L
+        adminProductService.delete(adminId, productId)
+        return DeleteProductApiResponse()
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/UpdateProductApiRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/UpdateProductApiRequest.kt
@@ -22,7 +22,7 @@ data class UpdateProductApiRequest(
     val intensityId: Long,
     @field:NotNull(message = "컵사이즈 카테고리 아이디가 비어있습니다.")
     val cupSizeId: Long,
-    @field:NotNull(message = "ㅁㄴㅇㄹ")
+    @field:NotNull(message = "판매 상태 값이 비어있습니다.")
     val status: SellingStatus,
 ) {
     fun toServiceRequest(productId: Long): UpdateProductRequest =

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/UpdateProductApiRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/UpdateProductApiRequest.kt
@@ -1,0 +1,40 @@
+package com.fastcampus.commerce.admin.product.interfaces.request
+
+import com.fastcampus.commerce.admin.product.application.request.UpdateProductRequest
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
+
+data class UpdateProductApiRequest(
+    @field:NotBlank(message = "파일명이 비어있습니다.")
+    val name: String,
+    @field:Positive(message = "가격은 양수여야합니다.")
+    val price: Int,
+    @field:PositiveOrZero(message = "재고는 음수일 수 없습니다.")
+    val quantity: Int,
+    @field:NotBlank(message = "썸네일이 비어있습니다.")
+    val thumbnail: String,
+    @field:NotBlank(message = "상품 상세이미지가 비어있습니다.")
+    val detailImage: String,
+    @field:NotNull(message = "강도 카테고리 아이디가 비어있습니다.")
+    val intensityId: Long,
+    @field:NotNull(message = "컵사이즈 카테고리 아이디가 비어있습니다.")
+    val cupSizeId: Long,
+    @field:NotNull(message = "ㅁㄴㅇㄹ")
+    val status: SellingStatus,
+) {
+    fun toServiceRequest(productId: Long): UpdateProductRequest =
+        UpdateProductRequest(
+            id = productId,
+            name = name,
+            price = price,
+            quantity = quantity,
+            detailImage = detailImage,
+            thumbnail = thumbnail,
+            intensityId = intensityId,
+            cupSizeId = cupSizeId,
+            status = status,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/DeleteProductApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/DeleteProductApiResponse.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.admin.product.interfaces.response
+
+data class DeleteProductApiResponse(
+    val message: String = "OK",
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/UpdateProductApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/UpdateProductApiResponse.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.admin.product.interfaces.response
+
+data class UpdateProductApiResponse(
+    val productId: Long,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductCommandService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductCommandService.kt
@@ -29,4 +29,10 @@ class ProductCommandService(
     fun updateInventory(command: ProductUpdater) {
         productStore.updateQuantityByProductId(command.id, command.quantity)
     }
+
+    @Transactional(readOnly = false)
+    fun deleteProduct(productId: Long) {
+        productStore.deleteProductWithInventory(productId)
+        categoryStore.removeProductCategories(productId)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductCommandService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductCommandService.kt
@@ -1,9 +1,9 @@
 package com.fastcampus.commerce.product.application
 
+import com.fastcampus.commerce.product.domain.model.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductUpdater
 import com.fastcampus.commerce.product.domain.service.CategoryStore
 import com.fastcampus.commerce.product.domain.service.ProductStore
-import com.fastcampus.commerce.product.domain.service.dto.ProductRegister
-import com.fastcampus.commerce.product.domain.model.ProductRegister
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,5 +18,15 @@ class ProductCommandService(
         val productId = product.id!!
         categoryStore.mappingProductCategories(productId, command.categoryIds)
         return productId
+    }
+
+    @Transactional(readOnly = false)
+    fun updateProduct(command: ProductUpdater) {
+        productStore.updateProduct(command)
+    }
+
+    @Transactional(readOnly = false)
+    fun updateInventory(command: ProductUpdater) {
+        productStore.updateQuantityByProductId(command.id, command.quantity)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductCommandService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductCommandService.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.application
 import com.fastcampus.commerce.product.domain.service.CategoryStore
 import com.fastcampus.commerce.product.domain.service.ProductStore
 import com.fastcampus.commerce.product.domain.service.dto.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductRegister
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Inventory.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Inventory.kt
@@ -1,6 +1,8 @@
 package com.fastcampus.commerce.product.domain.entity
 
 import com.fastcampus.commerce.common.entity.BaseEntity
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.product.domain.error.ProductErrorCode
 import org.springframework.data.annotation.LastModifiedDate
 import java.time.LocalDateTime
 import jakarta.persistence.Column
@@ -26,7 +28,22 @@ class Inventory(
     @Column(nullable = false)
     lateinit var updatedAt: LocalDateTime
 
+    init {
+        validate()
+    }
+
+    fun validate() {
+        validateQuantity()
+    }
+
+    private fun validateQuantity() {
+        if (quantity < 0) {
+            throw CoreException(ProductErrorCode.QUANTITY_NEGATIVE)
+        }
+    }
+
     fun updateQuantity(quantity: Int) {
         this.quantity = quantity
+        validate()
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Product.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Product.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.domain.entity
 import com.fastcampus.commerce.common.entity.BaseEntity
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.error.ProductErrorCode
+import com.fastcampus.commerce.product.domain.model.ProductUpdater
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
@@ -46,6 +47,7 @@ class Product(
 
     @Column
     var deletedAt: LocalDateTime? = null
+
     init {
         validate()
     }
@@ -68,6 +70,15 @@ class Product(
         if (price <= 0) {
             throw CoreException(ProductErrorCode.PRICE_NOT_POSITIVE)
         }
+    }
+
+    fun update(updater: ProductUpdater) {
+        this.name = updater.name
+        this.price = updater.price
+        this.thumbnail = updater.thumbnail
+        this.detailImage = updater.detailImage
+        this.status = updater.status
+        validate()
     }
 
     companion object {

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Product.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Product.kt
@@ -1,6 +1,8 @@
 package com.fastcampus.commerce.product.domain.entity
 
 import com.fastcampus.commerce.common.entity.BaseEntity
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.product.domain.error.ProductErrorCode
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
@@ -44,4 +46,31 @@ class Product(
 
     @Column
     var deletedAt: LocalDateTime? = null
+    init {
+        validate()
+    }
+
+    fun validate() {
+        validateName()
+        validatePrice()
+    }
+
+    private fun validateName() {
+        if (name.isBlank()) {
+            throw CoreException(ProductErrorCode.PRODUCT_NAME_EMPTY)
+        }
+        if (name.length > MAX_NAME_LENGTH) {
+            throw CoreException(ProductErrorCode.PRODUCT_NAME_TOO_LONG)
+        }
+    }
+
+    private fun validatePrice() {
+        if (price <= 0) {
+            throw CoreException(ProductErrorCode.PRICE_NOT_POSITIVE)
+        }
+    }
+
+    companion object {
+        const val MAX_NAME_LENGTH = 255
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/error/ProductErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/error/ProductErrorCode.kt
@@ -9,7 +9,7 @@ enum class ProductErrorCode(
     override val logLevel: LogLevel,
 ) : ErrorCode {
     PRODUCT_NOT_FOUND("PRO-001", "상품을 찾을 수 없습니다.", LogLevel.WARN),
-    INVENTORY_NOT_FOUND("PRO-002","상품 재고를 찾을 수 없습니다.",LogLevel.WARN),
+    INVENTORY_NOT_FOUND("PRO-002", "상품 재고를 찾을 수 없습니다.", LogLevel.WARN),
 
     PRODUCT_NAME_EMPTY("PRD-101", "상품명이 비어있습니다.", LogLevel.WARN),
     PRODUCT_NAME_TOO_LONG("PRD-102", "상품명이 너무 깁니다.", LogLevel.WARN),

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/model/ProductRegister.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/model/ProductRegister.kt
@@ -1,4 +1,4 @@
-package com.fastcampus.commerce.product.domain.service.dto
+package com.fastcampus.commerce.product.domain.model
 
 import com.fastcampus.commerce.product.domain.entity.Product
 

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/model/ProductUpdater.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/model/ProductUpdater.kt
@@ -1,0 +1,15 @@
+package com.fastcampus.commerce.product.domain.model
+
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+
+data class ProductUpdater(
+    val id: Long,
+    val name: String,
+    val price: Int,
+    val quantity: Int,
+    val detailImage: String,
+    val thumbnail: String,
+    val categoryIds: List<Long>,
+    val status: SellingStatus,
+    val updaterId: Long,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/InventoryRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/InventoryRepository.kt
@@ -9,4 +9,6 @@ interface InventoryRepository {
     fun findByProductId(productId: Long): Optional<Inventory>
 
     fun findByProductIdForUpdate(productId: Long): Optional<Inventory>
+
+    fun delete(inventory: Inventory)
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/InventoryRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/InventoryRepository.kt
@@ -7,4 +7,6 @@ interface InventoryRepository {
     fun save(inventory: Inventory): Inventory
 
     fun findByProductId(productId: Long): Optional<Inventory>
+
+    fun findByProductIdForUpdate(productId: Long): Optional<Inventory>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductCategoryRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductCategoryRepository.kt
@@ -4,4 +4,8 @@ import com.fastcampus.commerce.product.domain.entity.ProductCategory
 
 interface ProductCategoryRepository {
     fun saveAll(productCategories: List<ProductCategory>): List<ProductCategory>
+
+    fun getAllByProductId(productId: Long): List<ProductCategory>
+
+    fun deleteAll(productCategories: List<ProductCategory>)
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductRepository.kt
@@ -1,7 +1,10 @@
 package com.fastcampus.commerce.product.domain.repository
 
 import com.fastcampus.commerce.product.domain.entity.Product
+import java.util.Optional
 
 interface ProductRepository {
     fun save(product: Product): Product
+
+    fun findById(productId: Long): Optional<Product>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductRepository.kt
@@ -7,4 +7,6 @@ interface ProductRepository {
     fun save(product: Product): Product
 
     fun findById(productId: Long): Optional<Product>
+
+    fun delete(product: Product)
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/CategoryReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/CategoryReader.kt
@@ -1,13 +1,20 @@
 package com.fastcampus.commerce.product.domain.service
 
+import com.fastcampus.commerce.product.domain.entity.ProductCategory
 import com.fastcampus.commerce.product.domain.repository.CategoryRepository
+import com.fastcampus.commerce.product.domain.repository.ProductCategoryRepository
 import org.springframework.stereotype.Component
 
 @Component
 class CategoryReader(
     private val categoryRepository: CategoryRepository,
+    private val productCategoryRepository: ProductCategoryRepository,
 ) {
     fun countCategoriesByIds(categoryIds: List<Long>): Long {
         return categoryRepository.countCategoriesByIds(categoryIds)
+    }
+
+    fun getAllProductCategoriesByProductId(productId: Long): List<ProductCategory> {
+        return productCategoryRepository.getAllByProductId(productId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/CategoryStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/CategoryStore.kt
@@ -5,12 +5,14 @@ import com.fastcampus.commerce.product.domain.entity.ProductCategory
 import com.fastcampus.commerce.product.domain.error.ProductErrorCode
 import com.fastcampus.commerce.product.domain.repository.ProductCategoryRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CategoryStore(
     private val categoryReader: CategoryReader,
     private val productCategoryRepository: ProductCategoryRepository,
 ) {
+    @Transactional(readOnly = false)
     fun mappingProductCategories(productId: Long, categoryIds: List<Long>): List<ProductCategory> {
         val existsCount = categoryReader.countCategoriesByIds(categoryIds)
         if (existsCount != categoryIds.size.toLong()) {
@@ -18,5 +20,11 @@ class CategoryStore(
         }
         val productCategories = categoryIds.map { ProductCategory(productId = productId, categoryId = it) }
         return productCategoryRepository.saveAll(productCategories)
+    }
+
+    @Transactional(readOnly = false)
+    fun removeProductCategories(productId: Long) {
+        val productCategories: List<ProductCategory> = categoryReader.getAllProductCategoriesByProductId(productId)
+        productCategoryRepository.deleteAll(productCategories)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductReader.kt
@@ -2,16 +2,24 @@ package com.fastcampus.commerce.product.domain.service
 
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.entity.Inventory
+import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.error.ProductErrorCode
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
-import org.springframework.stereotype.Service
+import com.fastcampus.commerce.product.domain.repository.ProductRepository
+import org.springframework.stereotype.Component
 
-@Service
-class ProductReader (
+@Component
+class ProductReader(
+    private val productRepository: ProductRepository,
     private val inventoryRepository: InventoryRepository,
-){
+) {
     fun getInventoryByProductId(productId: Long): Inventory {
         return inventoryRepository.findByProductId(productId)
         .orElseThrow { CoreException(ProductErrorCode.INVENTORY_NOT_FOUND) }
+    }
+
+    fun getProductById(productId: Long): Product {
+        return productRepository.findById(productId)
+            .orElseThrow { CoreException(ProductErrorCode.PRODUCT_NOT_FOUND) }
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductReader.kt
@@ -15,7 +15,12 @@ class ProductReader(
 ) {
     fun getInventoryByProductId(productId: Long): Inventory {
         return inventoryRepository.findByProductId(productId)
-        .orElseThrow { CoreException(ProductErrorCode.INVENTORY_NOT_FOUND) }
+            .orElseThrow { CoreException(ProductErrorCode.INVENTORY_NOT_FOUND) }
+    }
+
+    fun getInventoryByProductIdForUpdate(productId: Long): Inventory {
+        return inventoryRepository.findByProductIdForUpdate(productId)
+            .orElseThrow { CoreException(ProductErrorCode.INVENTORY_NOT_FOUND) }
     }
 
     fun getProductById(productId: Long): Product {

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
@@ -34,4 +34,12 @@ class ProductStore(
         val inventory = productReader.getInventoryByProductIdForUpdate(productId)
         inventory.updateQuantity(quantity)
     }
+
+    @Transactional(readOnly = false)
+    fun deleteProductWithInventory(productId: Long) {
+        val product = productReader.getProductById(productId)
+        productRepository.delete(product)
+        val inventory = productReader.getInventoryByProductId(productId)
+        inventoryRepository.delete(inventory)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
@@ -2,9 +2,9 @@ package com.fastcampus.commerce.product.domain.service
 
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
+import com.fastcampus.commerce.product.domain.model.ProductRegister
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
 import com.fastcampus.commerce.product.domain.repository.ProductRepository
-import com.fastcampus.commerce.product.domain.service.dto.ProductRegister
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
@@ -28,4 +28,10 @@ class ProductStore(
         val product = productReader.getProductById(command.id)
         product.update(command)
     }
+
+    @Transactional(readOnly = false)
+    fun updateQuantityByProductId(productId: Long, quantity: Int) {
+        val inventory = productReader.getInventoryByProductIdForUpdate(productId)
+        inventory.updateQuantity(quantity)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.domain.service
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.model.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductUpdater
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
 import com.fastcampus.commerce.product.domain.repository.ProductRepository
 import org.springframework.stereotype.Component
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 class ProductStore(
     private val productRepository: ProductRepository,
     private val inventoryRepository: InventoryRepository,
+    private val productReader: ProductReader,
 ) {
     @Transactional(readOnly = false)
     fun saveProductWithInventory(command: ProductRegister): Product {
@@ -19,5 +21,11 @@ class ProductStore(
         val productId = product.id!!
         inventoryRepository.save(Inventory(productId = productId, quantity = command.quantity))
         return product
+    }
+
+    @Transactional(readOnly = false)
+    fun updateProduct(command: ProductUpdater) {
+        val product = productReader.getProductById(command.id)
+        product.update(command)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
@@ -2,5 +2,11 @@ package com.fastcampus.commerce.product.infrastructure
 
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import java.util.Optional
+import jakarta.persistence.LockModeType
 
-interface InventoryJpaRepository : JpaRepository<Inventory, Long>
+interface InventoryJpaRepository : JpaRepository<Inventory, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByProductidForUpdate(productId: Long): Optional<Inventory>
+}

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
@@ -8,5 +8,5 @@ import jakarta.persistence.LockModeType
 
 interface InventoryJpaRepository : JpaRepository<Inventory, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    fun findByProductidForUpdate(productId: Long): Optional<Inventory>
+    fun findByProductIdForUpdate(productId: Long): Optional<Inventory>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.LockModeType
 
 interface InventoryJpaRepository : JpaRepository<Inventory, Long> {
     fun findByProductId(productId: Long): Optional<Inventory>
-  
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByProductIdForUpdate(productId: Long): Optional<Inventory>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryRepositoryImpl.kt
@@ -20,4 +20,8 @@ class InventoryRepositoryImpl(
     override fun findByProductIdForUpdate(productId: Long): Optional<Inventory> {
         return inventoryJpaRepository.findByProductidForUpdate(productId)
     }
+
+    override fun delete(inventory: Inventory) {
+        inventoryJpaRepository.delete(inventory)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryRepositoryImpl.kt
@@ -18,7 +18,7 @@ class InventoryRepositoryImpl(
     }
 
     override fun findByProductIdForUpdate(productId: Long): Optional<Inventory> {
-        return inventoryJpaRepository.findByProductidForUpdate(productId)
+        return inventoryJpaRepository.findByProductIdForUpdate(productId)
     }
 
     override fun delete(inventory: Inventory) {

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.fastcampus.commerce.product.infrastructure
 
 import com.fastcampus.commerce.product.domain.entity.Inventory
-import com.fastcampus.commerce.product.domain.entity.QInventory.inventory
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
 import org.springframework.stereotype.Repository
 import java.util.Optional
@@ -18,4 +17,7 @@ class InventoryRepositoryImpl(
         return inventoryJpaRepository.findById(productId)
     }
 
+    override fun findByProductIdForUpdate(productId: Long): Optional<Inventory> {
+        return inventoryJpaRepository.findByProductidForUpdate(productId)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductCategoryJpaRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductCategoryJpaRepository.kt
@@ -3,4 +3,6 @@ package com.fastcampus.commerce.product.infrastructure
 import com.fastcampus.commerce.product.domain.entity.ProductCategory
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ProductCategoryJpaRepository : JpaRepository<ProductCategory, Long>
+interface ProductCategoryJpaRepository : JpaRepository<ProductCategory, Long> {
+    fun findAllByProductId(productId: Long): List<ProductCategory>
+}

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductCategoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductCategoryRepositoryImpl.kt
@@ -11,4 +11,12 @@ class ProductCategoryRepositoryImpl(
     override fun saveAll(productCategories: List<ProductCategory>): List<ProductCategory> {
         return productCategoryJpaRepository.saveAll(productCategories)
     }
+
+    override fun getAllByProductId(productId: Long): List<ProductCategory> {
+        return productCategoryJpaRepository.findAllByProductId(productId)
+    }
+
+    override fun deleteAll(productCategories: List<ProductCategory>) {
+        productCategoryJpaRepository.deleteAll(productCategories)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.infrastructure
 import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.repository.ProductRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
 class ProductRepositoryImpl(
@@ -10,5 +11,9 @@ class ProductRepositoryImpl(
 ) : ProductRepository {
     override fun save(product: Product): Product {
         return productJpaRepository.save(product)
+    }
+
+    override fun findById(productId: Long): Optional<Product> {
+        return productJpaRepository.findById(productId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/ProductRepositoryImpl.kt
@@ -16,4 +16,8 @@ class ProductRepositoryImpl(
     override fun findById(productId: Long): Optional<Product> {
         return productJpaRepository.findById(productId)
     }
+
+    override fun delete(product: Product) {
+        productJpaRepository.delete(product)
+    }
 }

--- a/src/test/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductServiceTest.kt
@@ -148,5 +148,22 @@ class AdminProductServiceTest : DescribeSpec(
                 }
             }
         }
+
+        describe("상품 삭제") {
+            val deleterId = 1L
+            val productId = 1L
+
+            it("상품을 삭제할 수 있다.") {
+                every { productCommandService.deleteProduct(productId) } returns Unit
+                every { transactionTemplate.execute(any<TransactionCallback<Unit>>()) } answers {
+                    val callback = it.invocation.args[0] as TransactionCallback<Unit>
+                    callback.doInTransaction(mockk(relaxed = true))
+                }
+
+                service.delete(deleterId, productId)
+
+                verify(exactly = 1) { productCommandService.deleteProduct(productId) }
+            }
+        }
     },
 )

--- a/src/test/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductControllerTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductControllerTest.kt
@@ -3,11 +3,15 @@ package com.fastcampus.commerce.admin.product.interfaces
 import com.fastcampus.commerce.admin.product.application.AdminProductService
 import com.fastcampus.commerce.admin.product.application.response.SellingStatusResponse
 import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
+import com.fastcampus.commerce.admin.product.interfaces.request.UpdateProductApiRequest
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.restdoc.documentation
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
@@ -103,6 +107,57 @@ class AdminProductControllerTest : DescribeSpec() {
 
                     responseBody {
                         field("data.productId", "생성된 상품 아이디", 10)
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
+
+        describe("PUT /admin/products/{productId} - 상품 수정") {
+            val summary = "상품을 수정할 수 있다."
+
+            it("상품을 수정할 수 있다.") {
+                val productId = 10L
+                val request = UpdateProductApiRequest(
+                    name = "콜드브루",
+                    price = 3500,
+                    quantity = 100,
+                    thumbnail = "https://test.com/thumbnail.png",
+                    detailImage = "https://test.com/detailImage.png",
+                    intensityId = 1L,
+                    cupSizeId = 10L,
+                    status = SellingStatus.UNAVAILABLE,
+                )
+
+                every { adminProductService.update(any<Long>(), request.toServiceRequest(productId)) } just Runs
+
+                documentation(
+                    identifier = "상품_수정_성공",
+                    tag = tag,
+                    summary = summary,
+                    privateResource = privateResource,
+                ) {
+                    requestLine(HttpMethod.PUT, "/admin/products/{productId}") {
+                        pathVariable("productId", "상품 아이디", productId)
+                    }
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    requestBody {
+                        field("name", "상품명", request.name)
+                        field("price", "가격", request.price)
+                        field("quantity", "재고 수량", request.quantity)
+                        field("thumbnail", "썸네일 이미지", request.thumbnail)
+                        field("detailImage", "상세 이미지", request.detailImage)
+                        field("intensityId", "강도 카테고리 아이디", request.intensityId)
+                        field("cupSizeId", "컵사이즈 카테고리 아이디", request.cupSizeId)
+                        field("status", "판매상태 코드", request.status)
+                    }
+
+                    responseBody {
+                        field("data.productId", "수정된 상품 아이디", productId.toInt())
                         ignoredField("error")
                     }
                 }

--- a/src/test/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductControllerTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductControllerTest.kt
@@ -163,5 +163,33 @@ class AdminProductControllerTest : DescribeSpec() {
                 }
             }
         }
+        describe("DELETE /admin/products/{productId} - 상품 삭제") {
+            val summary = "상품을 삭제할 수 있다."
+
+            it("상품을 삭제할 수 있다.") {
+                val productId = 10L
+                every { adminProductService.delete(any<Long>(), productId) } just Runs
+
+                documentation(
+                    identifier = "상품_삭제_성공",
+                    tag = tag,
+                    summary = summary,
+                    privateResource = privateResource,
+                ) {
+                    requestLine(HttpMethod.DELETE, "/admin/products/{productId}") {
+                        pathVariable("productId", "상품 아이디", productId)
+                    }
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    responseBody {
+                        field("data.message", "응답 메시지", "OK")
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/fastcampus/commerce/product/application/ProductCommandServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/application/ProductCommandServiceTest.kt
@@ -1,12 +1,16 @@
 package com.fastcampus.commerce.product.application
 
 import com.fastcampus.commerce.product.domain.entity.Product
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.model.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductUpdater
 import com.fastcampus.commerce.product.domain.service.CategoryStore
 import com.fastcampus.commerce.product.domain.service.ProductStore
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 
@@ -52,6 +56,44 @@ class ProductCommandServiceTest : FunSpec(
 
             verify(exactly = 1) { productStore.saveProductWithInventory(register) }
             verify(exactly = 1) { categoryStore.mappingProductCategories(expectedProductId, expectedCategoryIds) }
+        }
+
+        test("상품 ID를 상품 정보를 수정할 수 있다.") {
+            val updater = ProductUpdater(
+                id = 1L,
+                name = "아메리카노",
+                price = 3000,
+                quantity = 100,
+                detailImage = "https://test.com/detail.png",
+                thumbnail = "https://test.com/thumb.png",
+                categoryIds = listOf(1L, 2L),
+                status = SellingStatus.ON_SALE,
+                updaterId = 10L,
+            )
+            every { productStore.updateProduct(updater) } just Runs
+
+            productCommandService.updateProduct(updater)
+
+            verify(exactly = 1) { productStore.updateProduct(updater) }
+        }
+
+        test("상품 ID를 기반으로 재고를 수정할 수 있다.") {
+            val updater = ProductUpdater(
+                id = 1L,
+                name = "아메리카노",
+                price = 3000,
+                quantity = 150,
+                detailImage = "https://test.com/detail.png",
+                thumbnail = "https://test.com/thumb.png",
+                categoryIds = listOf(1L, 2L),
+                status = SellingStatus.ON_SALE,
+                updaterId = 10L,
+            )
+            every { productStore.updateQuantityByProductId(updater.id, updater.quantity) } just Runs
+
+            productCommandService.updateInventory(updater)
+
+            verify(exactly = 1) { productStore.updateQuantityByProductId(updater.id, updater.quantity) }
         }
     },
 )

--- a/src/test/kotlin/com/fastcampus/commerce/product/application/ProductCommandServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/application/ProductCommandServiceTest.kt
@@ -95,5 +95,17 @@ class ProductCommandServiceTest : FunSpec(
 
             verify(exactly = 1) { productStore.updateQuantityByProductId(updater.id, updater.quantity) }
         }
+
+        test("상품 ID를 기반으로 상품, 재고, 카테고리 매핑 정보를 함께 삭제할 수 있다.") {
+            val productId = 1L
+
+            every { productStore.deleteProductWithInventory(productId) } just Runs
+            every { categoryStore.removeProductCategories(productId) } just Runs
+
+            productCommandService.deleteProduct(productId)
+
+            verify(exactly = 1) { productStore.deleteProductWithInventory(productId) }
+            verify(exactly = 1) { categoryStore.removeProductCategories(productId) }
+        }
     },
 )

--- a/src/test/kotlin/com/fastcampus/commerce/product/application/ProductCommandServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/application/ProductCommandServiceTest.kt
@@ -1,9 +1,9 @@
 package com.fastcampus.commerce.product.application
 
 import com.fastcampus.commerce.product.domain.entity.Product
+import com.fastcampus.commerce.product.domain.model.ProductRegister
 import com.fastcampus.commerce.product.domain.service.CategoryStore
 import com.fastcampus.commerce.product.domain.service.ProductStore
-import com.fastcampus.commerce.product.domain.service.dto.ProductRegister
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/fastcampus/commerce/product/domain/service/CategoryReaderTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/domain/service/CategoryReaderTest.kt
@@ -1,5 +1,8 @@
 package com.fastcampus.commerce.product.domain.service
+
+import com.fastcampus.commerce.product.domain.entity.ProductCategory
 import com.fastcampus.commerce.product.domain.repository.CategoryRepository
+import com.fastcampus.commerce.product.domain.repository.ProductCategoryRepository
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
@@ -7,25 +10,44 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
-class CategoryReaderTest : FunSpec({
+class CategoryReaderTest : FunSpec(
+    {
 
-    val categoryRepository = mockk<CategoryRepository>()
-    val categoryReader = CategoryReader(categoryRepository)
+        val categoryRepository = mockk<CategoryRepository>()
+        val productCategoryRepository = mockk<ProductCategoryRepository>()
+        val categoryReader = CategoryReader(
+            categoryRepository = categoryRepository,
+            productCategoryRepository = productCategoryRepository,
+        )
 
-    beforeTest {
-        clearMocks(categoryRepository)
-    }
+        beforeTest {
+            clearMocks(categoryRepository, productCategoryRepository)
+        }
 
-    test("카테고리 ID 목록으로 카운트를 조회할 수 있다") {
-        val categoryIds = listOf(1L, 2L, 3L)
-        val expectedCount = 3L
+        test("카테고리 ID 목록으로 카운트를 조회할 수 있다") {
+            val categoryIds = listOf(1L, 2L, 3L)
+            val expectedCount = 3L
 
-        every { categoryRepository.countCategoriesByIds(categoryIds) } returns expectedCount
+            every { categoryRepository.countCategoriesByIds(categoryIds) } returns expectedCount
 
-        val result = categoryReader.countCategoriesByIds(categoryIds)
+            val result = categoryReader.countCategoriesByIds(categoryIds)
 
-        result shouldBe expectedCount
+            result shouldBe expectedCount
 
-        verify(exactly = 1) { categoryRepository.countCategoriesByIds(categoryIds) }
-    }
-})
+            verify(exactly = 1) { categoryRepository.countCategoriesByIds(categoryIds) }
+        }
+
+        test("상품 ID로 연관된 카테고리들을 조회할 수 있다.") {
+            val productId = 1L
+            val productCategories = listOf(
+                ProductCategory(productId = productId, categoryId = 10L),
+                ProductCategory(productId = productId, categoryId = 20L),
+            )
+            every { categoryReader.getAllProductCategoriesByProductId(productId) } returns productCategories
+
+            categoryReader.getAllProductCategoriesByProductId(productId)
+
+            verify(exactly = 1) { categoryReader.getAllProductCategoriesByProductId(productId) }
+        }
+    },
+)

--- a/src/test/kotlin/com/fastcampus/commerce/product/domain/service/CategoryStoreTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/domain/service/CategoryStoreTest.kt
@@ -9,8 +9,10 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 
@@ -81,6 +83,23 @@ class CategoryStoreTest : FunSpec(
 
                 verify(exactly = 1) { categoryReader.countCategoriesByIds(categoryIds) }
                 verify(exactly = 0) { productCategoryRepository.saveAll(any()) }
+            }
+        }
+
+        context("removeProductCategories") {
+            test("상품 ID로 연관된 카테고리들을 조회하고 모두 삭제할 수 있다.") {
+                val productId = 1L
+                val productCategories = listOf(
+                    ProductCategory(productId = productId, categoryId = 10L),
+                    ProductCategory(productId = productId, categoryId = 20L),
+                )
+                every { categoryReader.getAllProductCategoriesByProductId(productId) } returns productCategories
+                every { productCategoryRepository.deleteAll(productCategories) } just Runs
+
+                categoryStore.removeProductCategories(productId)
+
+                verify(exactly = 1) { categoryReader.getAllProductCategoriesByProductId(productId) }
+                verify(exactly = 1) { productCategoryRepository.deleteAll(productCategories) }
             }
         }
     },

--- a/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductStoreTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductStoreTest.kt
@@ -1,25 +1,36 @@
 package com.fastcampus.commerce.product.domain.service
 
+import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import com.fastcampus.commerce.product.domain.error.ProductErrorCode
+import com.fastcampus.commerce.product.domain.model.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductUpdater
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
 import com.fastcampus.commerce.product.domain.repository.ProductRepository
-import com.fastcampus.commerce.product.domain.model.ProductRegister
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 
 class ProductStoreTest : FunSpec(
     {
         val productRepository = mockk<ProductRepository>()
         val inventoryRepository = mockk<InventoryRepository>()
-        val productStore = ProductStore(productRepository, inventoryRepository)
+        val productReader = mockk<ProductReader>()
+        val productStore = ProductStore(
+            productRepository = productRepository,
+            inventoryRepository = inventoryRepository,
+            productReader = productReader,
+        )
 
         beforeTest {
-            clearMocks(productRepository, inventoryRepository)
+            clearMocks(productRepository, inventoryRepository, productReader)
         }
 
         test("상품과 재고를 함께 저장한다.") {
@@ -52,6 +63,65 @@ class ProductStoreTest : FunSpec(
 
             verify(exactly = 1) { productRepository.save(any<Product>()) }
             verify(exactly = 1) { inventoryRepository.save(any<Inventory>()) }
+        }
+
+        test("상품 업데이트 시 상품을 조회하고, 상태를 업데이트한다") {
+            val productId = 1L
+            val updater = ProductUpdater(
+                id = productId,
+                name = "아메리카노",
+                price = 3000,
+                quantity = 100,
+                detailImage = "https://test.com/detail.png",
+                thumbnail = "https://test.com/thumb.png",
+                categoryIds = listOf(1L, 2L),
+                status = SellingStatus.UNAVAILABLE,
+                updaterId = 10L,
+            )
+
+            val product = spyk(
+                Product(
+                    name = "old name",
+                    price = 1000,
+                    thumbnail = "old-thumb",
+                    detailImage = "old-detail",
+                    status = SellingStatus.ON_SALE,
+                ),
+            ).apply { id = productId }
+            every { productReader.getProductById(updater.id) } returns product
+
+            productStore.updateProduct(updater)
+
+            product.name shouldBe updater.name
+            product.price shouldBe updater.price
+            product.thumbnail shouldBe updater.thumbnail
+            product.detailImage shouldBe updater.detailImage
+            product.status shouldBe updater.status
+
+            verify(exactly = 1) { productReader.getProductById(updater.id) }
+            verify(exactly = 1) { product.update(updater) }
+        }
+
+        test("상품이 존재하지 않으면 PRODUCT_NOT_FOUND 예외가 발생한다.") {
+            val productId = 1L
+            val updater = ProductUpdater(
+                id = productId,
+                name = "아메리카노",
+                price = 3000,
+                quantity = 100,
+                detailImage = "https://test.com/detail.png",
+                thumbnail = "https://test.com/thumb.png",
+                categoryIds = listOf(1L, 2L),
+                status = SellingStatus.UNAVAILABLE,
+                updaterId = 10L,
+            )
+            every { productReader.getProductById(productId) } throws CoreException(ProductErrorCode.PRODUCT_NOT_FOUND)
+
+            shouldThrow<CoreException> {
+                productStore.updateProduct(updater)
+            }.errorCode shouldBe ProductErrorCode.PRODUCT_NOT_FOUND
+
+            verify(exactly = 1) { productReader.getProductById(productId) }
         }
     },
 )

--- a/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductStoreTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductStoreTest.kt
@@ -4,7 +4,7 @@ import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
 import com.fastcampus.commerce.product.domain.repository.ProductRepository
-import com.fastcampus.commerce.product.domain.service.dto.ProductRegister
+import com.fastcampus.commerce.product.domain.model.ProductRegister
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks

--- a/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductStoreTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductStoreTest.kt
@@ -123,5 +123,32 @@ class ProductStoreTest : FunSpec(
 
             verify(exactly = 1) { productReader.getProductById(productId) }
         }
+
+        test("재고 수량 업데이트 시 해당 상품의 인벤토리를 조회하고 수량을 변경한다.") {
+            val productId = 1L
+            val originalQuantity = 100
+            val inventory = spyk(Inventory(productId = productId, quantity = originalQuantity))
+            every { productReader.getInventoryByProductIdForUpdate(productId) } returns inventory
+            val quantity = 50
+
+            productStore.updateQuantityByProductId(productId, quantity)
+
+            inventory.quantity shouldBe quantity
+
+            verify(exactly = 1) { productReader.getInventoryByProductIdForUpdate(productId) }
+            verify(exactly = 1) { inventory.updateQuantity(quantity) }
+        }
+
+        test("재고가 존재하지 않으면 INVENTORY_NOT_FOUND 예외가 발생한다.") {
+            val productId = 1L
+            val quantity = 10
+            every { productReader.getInventoryByProductIdForUpdate(productId) } throws CoreException(ProductErrorCode.INVENTORY_NOT_FOUND)
+
+            shouldThrow<CoreException> {
+                productStore.updateQuantityByProductId(productId, quantity)
+            }.errorCode shouldBe ProductErrorCode.INVENTORY_NOT_FOUND
+
+            verify(exactly = 1) { productReader.getInventoryByProductIdForUpdate(productId) }
+        }
     },
 )


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
- 상품 수정/삭제 API 추가

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->
- 상품 수정 API 추가
- 상품 삭제 API 추가

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #31 

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->