### PR TITLE
[feat] 리뷰 등록 API 

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/common/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/config/QueryDslConfig.kt
@@ -1,0 +1,14 @@
+package com.fastcampus.commerce.common.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import jakarta.persistence.EntityManager
+
+@Configuration
+class QueryDslConfig(
+    private val entityManager: EntityManager,
+) {
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/com/fastcampus/commerce/common/util/SystemTimeProvider.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/util/SystemTimeProvider.kt
@@ -1,0 +1,9 @@
+package com.fastcampus.commerce.common.util
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class SystemTimeProvider : TimeProvider {
+    override fun now(): LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/fastcampus/commerce/common/util/TimeProvider.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/util/TimeProvider.kt
@@ -1,0 +1,7 @@
+package com.fastcampus.commerce.common.util
+
+import java.time.LocalDateTime
+
+interface TimeProvider {
+    fun now(): LocalDateTime
+}

--- a/src/main/kotlin/com/fastcampus/commerce/order/application/review/OrderReview.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/application/review/OrderReview.kt
@@ -1,0 +1,8 @@
+package com.fastcampus.commerce.order.application.review
+
+import java.time.LocalDateTime
+
+data class OrderReview(
+    val deliveredAt: LocalDateTime?,
+    val productId: Long,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/order/application/review/OrderReviewService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/application/review/OrderReviewService.kt
@@ -1,0 +1,16 @@
+package com.fastcampus.commerce.order.application.review
+
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.order.domain.error.OrderErrorCode
+import com.fastcampus.commerce.order.domain.repository.OrderReviewRepository
+import org.springframework.stereotype.Service
+
+@Service
+class OrderReviewService(
+    private val orderReviewRepository: OrderReviewRepository,
+) {
+    fun getReviewInfo(orderNumber: String, orderItemId: Long): OrderReview {
+        return orderReviewRepository.findOrderReview(orderNumber, orderItemId)
+            ?: throw CoreException(OrderErrorCode.ORDER_DATA_FOR_REVIEW_NOT_FOUND)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/error/OrderErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/error/OrderErrorCode.kt
@@ -1,0 +1,12 @@
+package com.fastcampus.commerce.order.domain.error
+
+import com.fastcampus.commerce.common.error.ErrorCode
+import com.fastcampus.commerce.common.error.LogLevel
+
+enum class OrderErrorCode(
+    override val code: String,
+    override val message: String,
+    override val logLevel: LogLevel,
+) : ErrorCode {
+    ORDER_DATA_FOR_REVIEW_NOT_FOUND("ORD-501", "리뷰 작성을 위한 주문데이터를 찾을 수 없습니다.", LogLevel.WARN),
+}

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/repository/OrderReviewRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/repository/OrderReviewRepository.kt
@@ -1,0 +1,7 @@
+package com.fastcampus.commerce.order.domain.repository
+
+import com.fastcampus.commerce.order.application.review.OrderReview
+
+interface OrderReviewRepository {
+    fun findOrderReview(orderNumber: String, orderItemId: Long): OrderReview?
+}

--- a/src/main/kotlin/com/fastcampus/commerce/order/infrastructure/OrderReviewRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/infrastructure/OrderReviewRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.fastcampus.commerce.order.infrastructure
+
+import com.fastcampus.commerce.order.application.review.OrderReview
+import com.fastcampus.commerce.order.domain.entity.QOrder.order
+import com.fastcampus.commerce.order.domain.entity.QOrderItem.orderItem
+import com.fastcampus.commerce.order.domain.entity.QProductSnapshot.productSnapshot
+import com.fastcampus.commerce.order.domain.repository.OrderReviewRepository
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class OrderReviewRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : OrderReviewRepository {
+    override fun findOrderReview(orderNumber: String, orderItemId: Long): OrderReview? {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    OrderReview::class.java,
+                    order.deliveredAt,
+                    productSnapshot.productId,
+                ),
+            )
+            .from(order)
+            .join(orderItem).on(order.id.eq(orderItem.orderId))
+            .join(productSnapshot).on(orderItem.productSnapshotId.eq(productSnapshot.id))
+            .where(
+                order.orderNumber.eq(orderNumber),
+                orderItem.id.eq(orderItemId),
+            )
+            .fetchOne()
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/ReviewCommandService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/ReviewCommandService.kt
@@ -1,0 +1,18 @@
+package com.fastcampus.commerce.review.application
+
+import com.fastcampus.commerce.order.application.review.OrderReviewService
+import com.fastcampus.commerce.review.application.request.RegisterReviewRequest
+import com.fastcampus.commerce.review.domain.service.ReviewStore
+import org.springframework.stereotype.Service
+
+@Service
+class ReviewCommandService(
+    private val orderReviewService: OrderReviewService,
+    private val reviewStore: ReviewStore,
+) {
+    fun registerReview(userId: Long, request: RegisterReviewRequest): Long {
+        val info = orderReviewService.getReviewInfo(request.orderNumber, request.orderItemId)
+        val review = reviewStore.register(request.toCommand(userId, info))
+        return review.id!!
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/request/RegisterReviewRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/request/RegisterReviewRequest.kt
@@ -1,0 +1,21 @@
+package com.fastcampus.commerce.review.application.request
+
+import com.fastcampus.commerce.order.application.review.OrderReview
+import com.fastcampus.commerce.review.domain.model.ReviewRegister
+
+data class RegisterReviewRequest(
+    val orderNumber: String,
+    val orderItemId: Long,
+    val rating: Int,
+    val content: String,
+) {
+    fun toCommand(userId: Long, orderReview: OrderReview): ReviewRegister =
+        ReviewRegister(
+            userId = userId,
+            orderItemId = orderItemId,
+            productId = orderReview.productId,
+            rating = rating,
+            content = content,
+            deliveredAt = orderReview.deliveredAt,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/entity/Review.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/entity/Review.kt
@@ -1,6 +1,8 @@
 package com.fastcampus.commerce.review.domain.entity
 
 import com.fastcampus.commerce.common.entity.BaseEntity
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
@@ -41,4 +43,38 @@ class Review(
 
     @Column
     var deletedAt: LocalDateTime? = null
+
+    init {
+        validate()
+    }
+
+    private fun validate() {
+        validateContent()
+        validateRating()
+    }
+
+    private fun validateContent() {
+        if (this.content.isBlank()) {
+            throw CoreException(ReviewErrorCode.CONTENT_EMPTY)
+        }
+    }
+
+    private fun validateRating() {
+        if (rating < 1 || rating > 5) {
+            throw CoreException(ReviewErrorCode.INVALID_RATING)
+        }
+    }
+
+    companion object {
+        const val MAX_WRITTEN_DATE = 30L
+
+        fun validateReviewWrittenDate(now: LocalDateTime, deliveredAt: LocalDateTime?) {
+            if (deliveredAt == null) {
+                throw CoreException(ReviewErrorCode.ORDER_NOT_DELIVERED)
+            }
+            if (deliveredAt.isBefore(now.minusDays(MAX_WRITTEN_DATE))) {
+                throw CoreException(ReviewErrorCode.TOO_LATE)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
@@ -12,4 +12,5 @@ enum class ReviewErrorCode(
     INVALID_RATING("RVW-002", "별점은 1~5점 사이로 선택해주세요.", LogLevel.WARN),
     ORDER_NOT_DELIVERED("RVW-003", "배송완료된 주문건에 대해서만 리뷰를 작성할 수 있습니다.", LogLevel.WARN),
     TOO_LATE("RVW-004", "배송완료 후 30일 이내의 주문건에 대해서만 리뷰를 작성 및 수정할 수 있습니다.", LogLevel.WARN),
+    ALREADY_WRITE("RVW-005", "리뷰는 주문 당 한번만 작성가능합니다.", LogLevel.WARN),
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
@@ -1,0 +1,15 @@
+package com.fastcampus.commerce.review.domain.error
+
+import com.fastcampus.commerce.common.error.ErrorCode
+import com.fastcampus.commerce.common.error.LogLevel
+
+enum class ReviewErrorCode(
+    override val code: String,
+    override val message: String,
+    override val logLevel: LogLevel,
+) : ErrorCode {
+    CONTENT_EMPTY("RVW-001", "리뷰 내용을 입력해주세요.", LogLevel.WARN),
+    INVALID_RATING("RVW-002", "별점은 1~5점 사이로 선택해주세요.", LogLevel.WARN),
+    ORDER_NOT_DELIVERED("RVW-003", "배송완료된 주문건에 대해서만 리뷰를 작성할 수 있습니다.", LogLevel.WARN),
+    TOO_LATE("RVW-004", "배송완료 후 30일 이내의 주문건에 대해서만 리뷰를 작성 및 수정할 수 있습니다.", LogLevel.WARN),
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ReviewRegister.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ReviewRegister.kt
@@ -1,0 +1,22 @@
+package com.fastcampus.commerce.review.domain.model
+
+import com.fastcampus.commerce.review.domain.entity.Review
+import java.time.LocalDateTime
+
+data class ReviewRegister(
+    val userId: Long,
+    val orderItemId: Long,
+    val productId: Long,
+    val rating: Int,
+    val content: String,
+    val deliveredAt: LocalDateTime? = null,
+) {
+    fun toReview(): Review =
+        Review(
+            userId = userId,
+            orderItemId = orderItemId,
+            productId = productId,
+            rating = rating,
+            content = content,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ReviewRepository.kt
@@ -1,5 +1,9 @@
 package com.fastcampus.commerce.review.domain.repository
 
+import com.fastcampus.commerce.review.domain.entity.Review
+
 interface ReviewRepository {
     fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean
+
+    fun save(review: Review): Review
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ReviewRepository.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.review.domain.repository
+
+interface ReviewRepository {
+    fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReader.kt
@@ -1,0 +1,13 @@
+package com.fastcampus.commerce.review.domain.service
+
+import com.fastcampus.commerce.review.domain.repository.ReviewRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ReviewReader(
+    private val reviewRepository: ReviewRepository,
+) {
+    fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean {
+        return reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStore.kt
@@ -1,0 +1,27 @@
+package com.fastcampus.commerce.review.domain.service
+
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.common.util.TimeProvider
+import com.fastcampus.commerce.review.domain.entity.Review
+import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
+import com.fastcampus.commerce.review.domain.model.ReviewRegister
+import com.fastcampus.commerce.review.domain.repository.ReviewRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ReviewStore(
+    private val timeProvider: TimeProvider,
+    private val reviewReader: ReviewReader,
+    private val reviewRepository: ReviewRepository,
+) {
+    @Transactional(readOnly = false)
+    fun register(register: ReviewRegister): Review {
+        Review.validateReviewWrittenDate(timeProvider.now(), register.deliveredAt)
+        val alreadyWritten = reviewReader.existsByUserIdAndOrderItemId(register.userId, register.orderItemId)
+        if (alreadyWritten) {
+            throw CoreException(ReviewErrorCode.ALREADY_WRITE)
+        }
+        return reviewRepository.save(register.toReview())
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewJpaRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.fastcampus.commerce.review.infrastructure
+
+import com.fastcampus.commerce.review.domain.entity.Review
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReviewJpaRepository : JpaRepository<Review, Long> {
+    fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.fastcampus.commerce.review.infrastructure
+
+import com.fastcampus.commerce.review.domain.repository.ReviewRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReviewRepositoryImpl(
+    private val reviewJpaRepository: ReviewJpaRepository,
+) : ReviewRepository {
+    override fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean {
+        return reviewJpaRepository.existsByUserIdAndOrderItemId(userId, orderItemId)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fastcampus.commerce.review.infrastructure
 
+import com.fastcampus.commerce.review.domain.entity.Review
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
 import org.springframework.stereotype.Repository
 
@@ -9,5 +10,9 @@ class ReviewRepositoryImpl(
 ) : ReviewRepository {
     override fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean {
         return reviewJpaRepository.existsByUserIdAndOrderItemId(userId, orderItemId)
+    }
+
+    override fun save(review: Review): Review {
+        return reviewJpaRepository.save(review)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ReviewController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ReviewController.kt
@@ -1,0 +1,24 @@
+package com.fastcampus.commerce.review.interfaces
+
+import com.fastcampus.commerce.review.application.ReviewCommandService
+import com.fastcampus.commerce.review.interfaces.request.RegisterReviewApiRequest
+import com.fastcampus.commerce.review.interfaces.response.RegisterReviewApiResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/reviews")
+@RestController
+class ReviewController(
+    private val reviewCommandService: ReviewCommandService,
+) {
+    @PostMapping
+    fun registerReview(
+        @RequestBody request: RegisterReviewApiRequest,
+    ): RegisterReviewApiResponse {
+        val userId = 1L
+        val reviewId = reviewCommandService.registerReview(userId, request.toServiceRequest())
+        return RegisterReviewApiResponse(reviewId)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/request/RegisterReviewApiRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/request/RegisterReviewApiRequest.kt
@@ -1,0 +1,27 @@
+package com.fastcampus.commerce.review.interfaces.request
+
+import com.fastcampus.commerce.review.application.request.RegisterReviewRequest
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class RegisterReviewApiRequest(
+    @field:NotBlank(message = "주문번호가 비어있습니다.")
+    val orderNumber: String,
+    @field:NotNull(message = "주문 항목이 비어있습니다.")
+    val orderItemId: Long,
+    @field:Min(value = 1, message = "별점은 1~5점 사이로 선택해주세요.")
+    @field:Max(value = 5, message = "별점은 1~5점 사이로 선택해주세요.")
+    val rating: Int,
+    @field:NotBlank(message = "리뷰내용을 입력해주세요.")
+    val content: String,
+) {
+    fun toServiceRequest(): RegisterReviewRequest =
+        RegisterReviewRequest(
+            orderNumber = orderNumber,
+            orderItemId = orderItemId,
+            rating = rating,
+            content = content,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/RegisterReviewApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/RegisterReviewApiResponse.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.review.interfaces.response
+
+data class RegisterReviewApiResponse(
+    val reviewId: Long,
+)

--- a/src/test/kotlin/com/fastcampus/commerce/common/util/FixedTimeProvider.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/common/util/FixedTimeProvider.kt
@@ -1,0 +1,7 @@
+package com.fastcampus.commerce.common.util
+
+import java.time.LocalDateTime
+
+class FixedTimeProvider : TimeProvider {
+    override fun now(): LocalDateTime = LocalDateTime.of(2025, 6, 4, 11, 39, 22)
+}

--- a/src/test/kotlin/com/fastcampus/commerce/order/application/review/OrderReviewServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/order/application/review/OrderReviewServiceTest.kt
@@ -1,0 +1,40 @@
+package com.fastcampus.commerce.order.application.review
+
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.order.domain.error.OrderErrorCode
+import com.fastcampus.commerce.order.domain.repository.OrderReviewRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class OrderReviewServiceTest : FunSpec({
+
+    val orderReviewRepository = mockk<OrderReviewRepository>()
+    val orderReviewService = OrderReviewService(orderReviewRepository)
+
+    val orderNumber = "ORDER1234"
+    val orderItemId = 100L
+
+    test("주문번호와 주문상품ID로 리뷰 대상 정보를 조회할 수 있다.") {
+        val orderReview = OrderReview(
+            deliveredAt = LocalDateTime.of(2025, 6, 4, 12, 0),
+            productId = 1L,
+        )
+        every { orderReviewRepository.findOrderReview(orderNumber, orderItemId) } returns orderReview
+
+        val result = orderReviewService.getReviewInfo(orderNumber, orderItemId)
+
+        result shouldBe orderReview
+    }
+
+    test("주문번호/주문상품ID에 해당하는 리뷰 대상 정보가 없으면 ORDER_DATA_FOR_REVIEW_NOT_FOUND 예외를 던진다.") {
+        every { orderReviewRepository.findOrderReview(orderNumber, orderItemId) } returns null
+
+        shouldThrow<CoreException> {
+            orderReviewService.getReviewInfo(orderNumber, orderItemId)
+        }.errorCode shouldBe OrderErrorCode.ORDER_DATA_FOR_REVIEW_NOT_FOUND
+    }
+})

--- a/src/test/kotlin/com/fastcampus/commerce/review/application/ReviewCommandServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/application/ReviewCommandServiceTest.kt
@@ -1,0 +1,68 @@
+package com.fastcampus.commerce.review.application
+
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.order.application.review.OrderReview
+import com.fastcampus.commerce.order.application.review.OrderReviewService
+import com.fastcampus.commerce.order.domain.error.OrderErrorCode
+import com.fastcampus.commerce.review.application.request.RegisterReviewRequest
+import com.fastcampus.commerce.review.domain.entity.Review
+import com.fastcampus.commerce.review.domain.service.ReviewStore
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class ReviewCommandServiceTest : FunSpec({
+
+    val orderReviewService = mockk<OrderReviewService>()
+    val reviewStore = mockk<ReviewStore>()
+    val reviewCommandService = ReviewCommandService(orderReviewService, reviewStore)
+
+    val userId = 1L
+
+    context("registerReview") {
+        val request = RegisterReviewRequest(
+            orderNumber = "ORDER1234",
+            orderItemId = 100L,
+            rating = 5,
+            content = "아주 좋아요!",
+        )
+
+        test("리뷰 등록 요청 시 리뷰가 생성되고 id를 반환한다") {
+            val orderReview = OrderReview(
+                deliveredAt = LocalDateTime.of(2025, 6, 1, 12, 0),
+                productId = 10L,
+            )
+            val command = request.toCommand(userId, orderReview)
+            val reviewId = 1L
+            val review = Review(
+                userId = command.userId,
+                orderItemId = command.orderItemId,
+                productId = command.productId,
+                rating = command.rating,
+                content = command.content,
+            ).apply { id = reviewId }
+
+            every {
+                orderReviewService.getReviewInfo(request.orderNumber, request.orderItemId)
+            } returns orderReview
+            every { reviewStore.register(command) } returns review
+
+            val result = reviewCommandService.registerReview(userId, request)
+
+            result shouldBe reviewId
+        }
+
+        test("리뷰 등록 요청 시 주문 정보가 없으면 ORDER_DATA_FOR_REVIEW_NOT_FOUND 예외가 발생한다.") {
+            every {
+                orderReviewService.getReviewInfo(request.orderNumber, request.orderItemId)
+            } throws CoreException(OrderErrorCode.ORDER_DATA_FOR_REVIEW_NOT_FOUND)
+
+            shouldThrow<CoreException> {
+                reviewCommandService.registerReview(userId, request)
+            }.errorCode shouldBe OrderErrorCode.ORDER_DATA_FOR_REVIEW_NOT_FOUND
+        }
+    }
+})

--- a/src/test/kotlin/com/fastcampus/commerce/review/domain/entity/ReviewTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/domain/entity/ReviewTest.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.commerce.review.domain.entity
+
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class ReviewTest : FunSpec({
+    val now = LocalDateTime.of(2025, 6, 4, 12, 0)
+
+    test("배송일자가 null이면 ORDER_NOT_DELIVERED 예외가 발생한다.") {
+        shouldThrow<CoreException> {
+            Review.validateReviewWrittenDate(now, null)
+        }.errorCode shouldBe ReviewErrorCode.ORDER_NOT_DELIVERED
+    }
+
+    test("리뷰 작성 기한이 지난 경우 TOO_LATE 예외가 발생한다.") {
+        val deliveredAt = now.minusDays(Review.MAX_WRITTEN_DATE + 1)
+
+        shouldThrow<CoreException> {
+            Review.validateReviewWrittenDate(now, deliveredAt)
+        }.errorCode shouldBe ReviewErrorCode.TOO_LATE
+    }
+
+    test("리뷰 작성 기한 이내이면 예외 발생하지 않는다.") {
+        val deliveredAt = now.minusDays(Review.MAX_WRITTEN_DATE - 1)
+
+        Review.validateReviewWrittenDate(now, deliveredAt)
+    }
+})

--- a/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReaderTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReaderTest.kt
@@ -1,0 +1,33 @@
+package com.fastcampus.commerce.review.domain.service
+
+import com.fastcampus.commerce.review.domain.repository.ReviewRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class ReviewReaderTest : FunSpec({
+    val reviewRepository = mockk<ReviewRepository>()
+    val reviewReader = ReviewReader(reviewRepository)
+
+    context("existsByUserIdAndOrderItemId") {
+        val userId = 1L
+        val orderItemId = 100L
+
+        test("userId와 orderItemId 조합으로 작성된 리뷰가 있으면 true를 반환한다.") {
+            every { reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId) } returns true
+
+            val result = reviewReader.existsByUserIdAndOrderItemId(userId, orderItemId)
+
+            result shouldBe true
+        }
+
+        test("userId와 orderItemId 조합으로 작성된 리뷰가 없으면 false를 반환한다.") {
+            every { reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId) } returns false
+
+            val result = reviewReader.existsByUserIdAndOrderItemId(userId, orderItemId)
+
+            result shouldBe false
+        }
+    }
+})

--- a/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStoreTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStoreTest.kt
@@ -1,0 +1,88 @@
+package com.fastcampus.commerce.review.domain.service
+
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.common.util.FixedTimeProvider
+import com.fastcampus.commerce.review.domain.entity.Review
+import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
+import com.fastcampus.commerce.review.domain.model.ReviewRegister
+import com.fastcampus.commerce.review.domain.repository.ReviewRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class ReviewStoreTest : FunSpec({
+    val timeProvider = FixedTimeProvider()
+    val reviewReader = mockk<ReviewReader>()
+    val reviewRepository = mockk<ReviewRepository>()
+    val reviewStore = ReviewStore(
+        timeProvider = timeProvider,
+        reviewReader = reviewReader,
+        reviewRepository = reviewRepository,
+    )
+
+    beforeEach {
+        clearAllMocks()
+    }
+
+    context("register") {
+        val register = ReviewRegister(
+            userId = 1L,
+            orderItemId = 100L,
+            productId = 10L,
+            rating = 5,
+            content = "좋아요",
+        )
+        test("리뷰가 정상적으로 등록된다") {
+            val deliveredAt = timeProvider.now().minusDays(Review.MAX_WRITTEN_DATE)
+            val validRegister = register.copy(deliveredAt = deliveredAt)
+            val review = validRegister.toReview()
+            every {
+                reviewReader.existsByUserIdAndOrderItemId(validRegister.userId, validRegister.orderItemId)
+            } returns false
+            every { reviewRepository.save(any<Review>()) } returns review
+
+            val result = reviewStore.register(validRegister)
+
+            result shouldBe review
+
+            verify(exactly = 1) { reviewRepository.save(any<Review>()) }
+        }
+
+        test("배송 시간이 null인 경우 ORDER_NOT_DELIVERED 예외가 발생한다.") {
+            val invalidRegister = register.copy(deliveredAt = null)
+
+            shouldThrow<CoreException> {
+                reviewStore.register(invalidRegister)
+            }.errorCode shouldBe ReviewErrorCode.ORDER_NOT_DELIVERED
+
+            verify(exactly = 0) { reviewRepository.save(any()) }
+        }
+
+        test("리뷰 작성 기한이 지나면 TOO_LATE 예외가 발생한다.") {
+            val deliveredAt = timeProvider.now().minusDays(Review.MAX_WRITTEN_DATE + 1)
+            val expiredRegister = register.copy(deliveredAt = deliveredAt)
+
+            shouldThrow<CoreException> {
+                reviewStore.register(expiredRegister)
+            }.errorCode shouldBe ReviewErrorCode.TOO_LATE
+
+            verify(exactly = 0) { reviewRepository.save(any()) }
+        }
+
+        test("이미 작성된 리뷰가 있으면 ALREADY_WRITE 예외가 발생한다.") {
+            val deliveredAt = timeProvider.now()
+            val register = register.copy(deliveredAt = deliveredAt)
+            every { reviewReader.existsByUserIdAndOrderItemId(register.userId, register.orderItemId) } returns true
+
+            shouldThrow<CoreException> {
+                reviewStore.register(register)
+            }.errorCode shouldBe ReviewErrorCode.ALREADY_WRITE
+
+            verify(exactly = 0) { reviewRepository.save(any()) }
+        }
+    }
+})

--- a/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ReviewControllerTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ReviewControllerTest.kt
@@ -1,0 +1,78 @@
+package com.fastcampus.commerce.review.interfaces
+
+import com.fastcampus.commerce.restdoc.documentation
+import com.fastcampus.commerce.review.application.ReviewCommandService
+import com.fastcampus.commerce.review.interfaces.request.RegisterReviewApiRequest
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.restassured.module.mockmvc.RestAssuredMockMvc
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.MockMvc
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@WebMvcTest(ReviewController::class)
+class ReviewControllerTest : DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var reviewCommandService: ReviewCommandService
+
+    val tag = "Review"
+
+    init {
+        beforeSpec {
+            RestAssuredMockMvc.mockMvc(mockMvc)
+        }
+
+        describe("POST /reviews - 리뷰 등록") {
+            val summary = "배송완료된 상품에 리뷰를 등록할 수 있다."
+
+            it("배송완료된 상품에 리뷰를 등록할 수 있다.") {
+                val userId = 1L
+                val request = RegisterReviewApiRequest(
+                    orderNumber = "ORDER1234",
+                    orderItemId = 10L,
+                    rating = 3,
+                    content = "좋습니다.",
+                )
+
+                every { reviewCommandService.registerReview(userId, request.toServiceRequest()) } returns 10L
+
+                documentation(
+                    identifier = "리뷰_등록_성공",
+                    tag = tag,
+                    summary = summary,
+                ) {
+                    requestLine(HttpMethod.POST, "/reviews")
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    requestBody {
+                        field("orderNumber", "주문번호", request.orderNumber)
+                        field("orderItemId", "주문 아이템 아이디", request.orderItemId)
+                        field("rating", "별점", request.rating)
+                        field("content", "리뷰 내용", request.content)
+                    }
+
+                    responseBody {
+                        field("data.reviewId", "생성된 리뷰 아이디", 10)
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
- 리뷰 등록 API

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->
- 리뷰 등록 API 추가
- "배송완료" 상태인 주문만 리뷰등록가능하므로 주문 도메인에 조회 로직 추가

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #34 

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->