### PR TITLE
[fix] 재고 조회 로직 버그 수정

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/InventoryJpaRepository.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.infrastructure
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 import java.util.Optional
 import jakarta.persistence.LockModeType
 
@@ -10,5 +11,6 @@ interface InventoryJpaRepository : JpaRepository<Inventory, Long> {
     fun findByProductId(productId: Long): Optional<Inventory>
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from Inventory c where c.productId = :productId")
     fun findByProductIdForUpdate(productId: Long): Optional<Inventory>
 }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
- 재고 조회 로직 버그 수정

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->
- `findByProductIdForUpdate` 에 `@Query` 붙임
---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #38 

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->