### PR TITLE
[feat] 리뷰 수정 API 추가

### DIFF
--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -6,6 +6,8 @@ info:
 servers:
 - url: http://localhost:8080
 tags:
+- name: Cart
+  description: 사용자 장바구니 API
 - name: Review
   description: 사용자 리뷰 API
 - name: Admin-File
@@ -272,6 +274,54 @@ paths:
                       },
                       "error" : null
                     }
+  /reviews/{reviewId}:
+    put:
+      tags:
+      - Review
+      summary: 리뷰를 수정할 수 있다.
+      operationId: 리뷰_수정_성공
+      parameters:
+      - name: reviewId
+        in: path
+        description: 리뷰 아이디
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: Authorization
+        required: true
+        schema:
+          type: string
+        example: Bearer sample-token
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/reviews-reviewId480882763"
+            examples:
+              리뷰_수정_성공:
+                value: |-
+                  {
+                    "rating" : 3,
+                    "content" : "좋습니다."
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/reviews-reviewId-168857718"
+              examples:
+                리뷰_수정_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "reviewId" : 10
+                      },
+                      "error" : null
+                    }
 components:
   schemas:
     admin-products9820101:
@@ -382,6 +432,29 @@ components:
             message:
               type: string
               description: 응답 메시지
+    reviews-reviewId480882763:
+      required:
+      - content
+      - rating
+      type: object
+      properties:
+        rating:
+          type: number
+          description: 별점
+        content:
+          type: string
+          description: 리뷰 내용
+    reviews-reviewId-168857718:
+      type: object
+      properties:
+        data:
+          required:
+          - reviewId
+          type: object
+          properties:
+            reviewId:
+              type: number
+              description: 수저된 리뷰 아이디
     admin-products-247955186:
       required:
       - cupSizeId

--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -454,7 +454,7 @@ components:
           properties:
             reviewId:
               type: number
-              description: 수저된 리뷰 아이디
+              description: 수정된 리뷰 아이디
     admin-products-247955186:
       required:
       - cupSizeId

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/ReviewCommandService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/ReviewCommandService.kt
@@ -2,6 +2,7 @@ package com.fastcampus.commerce.review.application
 
 import com.fastcampus.commerce.order.application.review.OrderReviewService
 import com.fastcampus.commerce.review.application.request.RegisterReviewRequest
+import com.fastcampus.commerce.review.application.request.UpdateReviewRequest
 import com.fastcampus.commerce.review.domain.service.ReviewStore
 import org.springframework.stereotype.Service
 
@@ -14,5 +15,10 @@ class ReviewCommandService(
         val info = orderReviewService.getReviewInfo(request.orderNumber, request.orderItemId)
         val review = reviewStore.register(request.toCommand(userId, info))
         return review.id!!
+    }
+
+    fun updateReview(userId: Long, reviewId: Long, request: UpdateReviewRequest): Long {
+        reviewStore.update(request.toCommand(userId, reviewId))
+        return reviewId
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/request/UpdateReviewRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/request/UpdateReviewRequest.kt
@@ -1,0 +1,16 @@
+package com.fastcampus.commerce.review.application.request
+
+import com.fastcampus.commerce.review.domain.model.ReviewUpdater
+
+data class UpdateReviewRequest(
+    val rating: Int,
+    val content: String,
+) {
+    fun toCommand(userId: Long, reviewId: Long): ReviewUpdater =
+        ReviewUpdater(
+            id = reviewId,
+            rating = rating,
+            content = content,
+            userId = userId,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/entity/Review.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/entity/Review.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.review.domain.entity
 import com.fastcampus.commerce.common.entity.BaseEntity
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
+import com.fastcampus.commerce.review.domain.model.ReviewUpdater
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
@@ -63,6 +64,12 @@ class Review(
         if (rating < 1 || rating > 5) {
             throw CoreException(ReviewErrorCode.INVALID_RATING)
         }
+    }
+
+    fun update(updater: ReviewUpdater) {
+        this.rating = updater.rating
+        this.content = updater.content
+        validate()
     }
 
     companion object {

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
@@ -13,4 +13,5 @@ enum class ReviewErrorCode(
     ORDER_NOT_DELIVERED("RVW-003", "배송완료된 주문건에 대해서만 리뷰를 작성할 수 있습니다.", LogLevel.WARN),
     TOO_LATE("RVW-004", "배송완료 후 30일 이내의 주문건에 대해서만 리뷰를 작성 및 수정할 수 있습니다.", LogLevel.WARN),
     ALREADY_WRITE("RVW-005", "리뷰는 주문 당 한번만 작성가능합니다.", LogLevel.WARN),
+    REVIEW_NOT_FOUND("RVW-006", "리뷰를 찾을 수 없습니다.", LogLevel.WARN),
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/error/ReviewErrorCode.kt
@@ -14,4 +14,5 @@ enum class ReviewErrorCode(
     TOO_LATE("RVW-004", "배송완료 후 30일 이내의 주문건에 대해서만 리뷰를 작성 및 수정할 수 있습니다.", LogLevel.WARN),
     ALREADY_WRITE("RVW-005", "리뷰는 주문 당 한번만 작성가능합니다.", LogLevel.WARN),
     REVIEW_NOT_FOUND("RVW-006", "리뷰를 찾을 수 없습니다.", LogLevel.WARN),
+    UNAUTHORIZED_REVIEW_UPDATE("RVW-007", "다른 사람의 리뷰를 수정할 수 없습니다", LogLevel.WARN),
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ReviewUpdater.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ReviewUpdater.kt
@@ -1,0 +1,8 @@
+package com.fastcampus.commerce.review.domain.model
+
+data class ReviewUpdater(
+    val id: Long,
+    val rating: Int,
+    val content: String,
+    val userId: Long,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ReviewRepository.kt
@@ -1,9 +1,12 @@
 package com.fastcampus.commerce.review.domain.repository
 
 import com.fastcampus.commerce.review.domain.entity.Review
+import java.util.Optional
 
 interface ReviewRepository {
     fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean
 
     fun save(review: Review): Review
+
+    fun findById(reviewId: Long): Optional<Review>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReader.kt
@@ -1,5 +1,8 @@
 package com.fastcampus.commerce.review.domain.service
 
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.review.domain.entity.Review
+import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
 import org.springframework.stereotype.Component
 
@@ -9,5 +12,10 @@ class ReviewReader(
 ) {
     fun existsByUserIdAndOrderItemId(userId: Long, orderItemId: Long): Boolean {
         return reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId)
+    }
+
+    fun getReviewById(reviewId: Long): Review {
+        return reviewRepository.findById(reviewId)
+            .orElseThrow { throw CoreException(ReviewErrorCode.REVIEW_NOT_FOUND) }
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStore.kt
@@ -5,6 +5,7 @@ import com.fastcampus.commerce.common.util.TimeProvider
 import com.fastcampus.commerce.review.domain.entity.Review
 import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
 import com.fastcampus.commerce.review.domain.model.ReviewRegister
+import com.fastcampus.commerce.review.domain.model.ReviewUpdater
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -23,5 +24,14 @@ class ReviewStore(
             throw CoreException(ReviewErrorCode.ALREADY_WRITE)
         }
         return reviewRepository.save(register.toReview())
+    }
+
+    @Transactional(readOnly = false)
+    fun update(command: ReviewUpdater) {
+        val review = reviewReader.getReviewById(command.id)
+        if (review.userId != command.userId) {
+            throw CoreException(ReviewErrorCode.UNAUTHORIZED_REVIEW_UPDATE)
+        }
+        review.update(command)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ReviewRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.review.infrastructure
 import com.fastcampus.commerce.review.domain.entity.Review
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
 class ReviewRepositoryImpl(
@@ -14,5 +15,9 @@ class ReviewRepositoryImpl(
 
     override fun save(review: Review): Review {
         return reviewJpaRepository.save(review)
+    }
+
+    override fun findById(reviewId: Long): Optional<Review> {
+        return reviewJpaRepository.findById(reviewId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ReviewController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ReviewController.kt
@@ -2,8 +2,12 @@ package com.fastcampus.commerce.review.interfaces
 
 import com.fastcampus.commerce.review.application.ReviewCommandService
 import com.fastcampus.commerce.review.interfaces.request.RegisterReviewApiRequest
+import com.fastcampus.commerce.review.interfaces.request.UpdateReviewApiRequest
 import com.fastcampus.commerce.review.interfaces.response.RegisterReviewApiResponse
+import com.fastcampus.commerce.review.interfaces.response.UpdateReviewApiResponse
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -20,5 +24,15 @@ class ReviewController(
         val userId = 1L
         val reviewId = reviewCommandService.registerReview(userId, request.toServiceRequest())
         return RegisterReviewApiResponse(reviewId)
+    }
+
+    @PutMapping("/{reviewId}")
+    fun updateReview(
+        @PathVariable reviewId: Long,
+        @RequestBody request: UpdateReviewApiRequest,
+    ): UpdateReviewApiResponse {
+        val userId = 1L
+        reviewCommandService.updateReview(userId, reviewId, request.toServiceRequest())
+        return UpdateReviewApiResponse(reviewId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/request/UpdateReviewApiRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/request/UpdateReviewApiRequest.kt
@@ -1,0 +1,13 @@
+package com.fastcampus.commerce.review.interfaces.request
+
+import com.fastcampus.commerce.review.application.request.UpdateReviewRequest
+
+data class UpdateReviewApiRequest (
+    val rating: Int,
+    val content: String,
+) {
+    fun toServiceRequest(): UpdateReviewRequest = UpdateReviewRequest(
+        rating = rating,
+        content = content,
+    )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/UpdateReviewApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/UpdateReviewApiResponse.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.review.interfaces.response
+
+data class UpdateReviewApiResponse (
+    val reviewId: Long,
+)

--- a/src/test/kotlin/com/fastcampus/commerce/file/interfaces/FileControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/file/interfaces/FileControllerRestDocTest.kt
@@ -1,17 +1,12 @@
 package com.fastcampus.commerce.file.interfaces
 
-import com.fastcampus.commerce.admin.product.application.AdminProductService
-import com.fastcampus.commerce.admin.product.interfaces.AdminProductController
-import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
 import com.fastcampus.commerce.file.application.FileCommandService
 import com.fastcampus.commerce.file.application.response.GeneratePresignedUrlResponse
 import com.fastcampus.commerce.file.interfaces.request.GeneratePresignedUrlApiRequest
 import com.fastcampus.commerce.restdoc.documentation
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
-import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,7 +21,7 @@ import java.util.UUID
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
 @WebMvcTest(FileController::class)
-class FileControllerRestDocTest: DescribeSpec() {
+class FileControllerRestDocTest : DescribeSpec() {
     override fun extensions() = listOf(SpringExtension)
 
     @Autowired
@@ -56,7 +51,7 @@ class FileControllerRestDocTest: DescribeSpec() {
                     contextId = "6d851850-3b6f-4230-97fe-1a55b44fc862",
                 )
 
-                val response =  GeneratePresignedUrlResponse(
+                val response = GeneratePresignedUrlResponse(
                     uploadUrl = "https://test-801base-bucket.com/product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg",
                     key = "product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg",
                     contextId = UUID.fromString("6d851850-3b6f-4230-97fe-1a55b44fc862"),

--- a/src/test/kotlin/com/fastcampus/commerce/review/application/ReviewCommandServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/application/ReviewCommandServiceTest.kt
@@ -5,13 +5,17 @@ import com.fastcampus.commerce.order.application.review.OrderReview
 import com.fastcampus.commerce.order.application.review.OrderReviewService
 import com.fastcampus.commerce.order.domain.error.OrderErrorCode
 import com.fastcampus.commerce.review.application.request.RegisterReviewRequest
+import com.fastcampus.commerce.review.application.request.UpdateReviewRequest
 import com.fastcampus.commerce.review.domain.entity.Review
 import com.fastcampus.commerce.review.domain.service.ReviewStore
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import java.time.LocalDateTime
 
 class ReviewCommandServiceTest : FunSpec({
@@ -63,6 +67,25 @@ class ReviewCommandServiceTest : FunSpec({
             shouldThrow<CoreException> {
                 reviewCommandService.registerReview(userId, request)
             }.errorCode shouldBe OrderErrorCode.ORDER_DATA_FOR_REVIEW_NOT_FOUND
+        }
+    }
+
+    context("updateReview") {
+        val reviewId = 1L
+        val updateRequest = UpdateReviewRequest(
+            rating = 4,
+            content = "별로였어요.",
+        )
+        val command = updateRequest.toCommand(userId, reviewId)
+
+        test("리뷰 수정 요청 시 ReviewStore.update가 호출되고 reviewId를 반환한다") {
+            every { reviewStore.update(command) } just Runs
+
+            val result = reviewCommandService.updateReview(userId, reviewId, updateRequest)
+
+            result shouldBe reviewId
+
+            verify(exactly = 1) { reviewStore.update(command) }
         }
     }
 })

--- a/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReaderTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewReaderTest.kt
@@ -1,33 +1,67 @@
 package com.fastcampus.commerce.review.domain.service
 
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.review.domain.entity.Review
+import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import java.util.Optional
 
-class ReviewReaderTest : FunSpec({
-    val reviewRepository = mockk<ReviewRepository>()
-    val reviewReader = ReviewReader(reviewRepository)
+class ReviewReaderTest : FunSpec(
+    {
+        val reviewRepository = mockk<ReviewRepository>()
+        val reviewReader = ReviewReader(reviewRepository)
 
-    context("existsByUserIdAndOrderItemId") {
-        val userId = 1L
-        val orderItemId = 100L
+        context("existsByUserIdAndOrderItemId") {
+            val userId = 1L
+            val orderItemId = 100L
 
-        test("userId와 orderItemId 조합으로 작성된 리뷰가 있으면 true를 반환한다.") {
-            every { reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId) } returns true
+            test("userId와 orderItemId 조합으로 작성된 리뷰가 있으면 true를 반환한다.") {
+                every { reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId) } returns true
 
-            val result = reviewReader.existsByUserIdAndOrderItemId(userId, orderItemId)
+                val result = reviewReader.existsByUserIdAndOrderItemId(userId, orderItemId)
 
-            result shouldBe true
+                result shouldBe true
+            }
+
+            test("userId와 orderItemId 조합으로 작성된 리뷰가 없으면 false를 반환한다.") {
+                every { reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId) } returns false
+
+                val result = reviewReader.existsByUserIdAndOrderItemId(userId, orderItemId)
+
+                result shouldBe false
+            }
         }
 
-        test("userId와 orderItemId 조합으로 작성된 리뷰가 없으면 false를 반환한다.") {
-            every { reviewRepository.existsByUserIdAndOrderItemId(userId, orderItemId) } returns false
+        context("getReviewById") {
+            val reviewId = 1L
 
-            val result = reviewReader.existsByUserIdAndOrderItemId(userId, orderItemId)
+            test("리뷰 아이디로 리뷰를 조회할 수 있다.") {
+                val review = Review(
+                    userId = 1L,
+                    orderItemId = 100L,
+                    productId = 10L,
+                    rating = 5,
+                    content = "좋습니다.",
+                )
+                every { reviewRepository.findById(reviewId) } returns Optional.of(review)
 
-            result shouldBe false
+                val result = reviewReader.getReviewById(reviewId)
+
+                result shouldBe review
+            }
+
+            test("리뷰 아이디와 일치하는 리뷰가 없으면 REVIEW_NOT_FOUND 예외가 발생한다.") {
+                every { reviewRepository.findById(reviewId) } returns Optional.empty()
+
+                shouldThrow<CoreException> {
+                    reviewReader.getReviewById(reviewId)
+                }.errorCode shouldBe ReviewErrorCode.REVIEW_NOT_FOUND
+            }
         }
-    }
-})
+    },
+)

--- a/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStoreTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/domain/service/ReviewStoreTest.kt
@@ -5,84 +5,125 @@ import com.fastcampus.commerce.common.util.FixedTimeProvider
 import com.fastcampus.commerce.review.domain.entity.Review
 import com.fastcampus.commerce.review.domain.error.ReviewErrorCode
 import com.fastcampus.commerce.review.domain.model.ReviewRegister
+import com.fastcampus.commerce.review.domain.model.ReviewUpdater
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 
-class ReviewStoreTest : FunSpec({
-    val timeProvider = FixedTimeProvider()
-    val reviewReader = mockk<ReviewReader>()
-    val reviewRepository = mockk<ReviewRepository>()
-    val reviewStore = ReviewStore(
-        timeProvider = timeProvider,
-        reviewReader = reviewReader,
-        reviewRepository = reviewRepository,
-    )
-
-    beforeEach {
-        clearAllMocks()
-    }
-
-    context("register") {
-        val register = ReviewRegister(
-            userId = 1L,
-            orderItemId = 100L,
-            productId = 10L,
-            rating = 5,
-            content = "좋아요",
+class ReviewStoreTest : FunSpec(
+    {
+        val timeProvider = FixedTimeProvider()
+        val reviewReader = mockk<ReviewReader>()
+        val reviewRepository = mockk<ReviewRepository>()
+        val reviewStore = ReviewStore(
+            timeProvider = timeProvider,
+            reviewReader = reviewReader,
+            reviewRepository = reviewRepository,
         )
-        test("리뷰가 정상적으로 등록된다") {
-            val deliveredAt = timeProvider.now().minusDays(Review.MAX_WRITTEN_DATE)
-            val validRegister = register.copy(deliveredAt = deliveredAt)
-            val review = validRegister.toReview()
-            every {
-                reviewReader.existsByUserIdAndOrderItemId(validRegister.userId, validRegister.orderItemId)
-            } returns false
-            every { reviewRepository.save(any<Review>()) } returns review
 
-            val result = reviewStore.register(validRegister)
-
-            result shouldBe review
-
-            verify(exactly = 1) { reviewRepository.save(any<Review>()) }
+        beforeEach {
+            clearAllMocks()
         }
 
-        test("배송 시간이 null인 경우 ORDER_NOT_DELIVERED 예외가 발생한다.") {
-            val invalidRegister = register.copy(deliveredAt = null)
+        context("register") {
+            val register = ReviewRegister(
+                userId = 1L,
+                orderItemId = 100L,
+                productId = 10L,
+                rating = 5,
+                content = "좋아요",
+            )
+            test("리뷰가 정상적으로 등록된다") {
+                val deliveredAt = timeProvider.now().minusDays(Review.MAX_WRITTEN_DATE)
+                val validRegister = register.copy(deliveredAt = deliveredAt)
+                val review = validRegister.toReview()
+                every {
+                    reviewReader.existsByUserIdAndOrderItemId(validRegister.userId, validRegister.orderItemId)
+                } returns false
+                every { reviewRepository.save(any<Review>()) } returns review
 
-            shouldThrow<CoreException> {
-                reviewStore.register(invalidRegister)
-            }.errorCode shouldBe ReviewErrorCode.ORDER_NOT_DELIVERED
+                val result = reviewStore.register(validRegister)
 
-            verify(exactly = 0) { reviewRepository.save(any()) }
+                result shouldBe review
+
+                verify(exactly = 1) { reviewRepository.save(any<Review>()) }
+            }
+
+            test("배송 시간이 null인 경우 ORDER_NOT_DELIVERED 예외가 발생한다.") {
+                val invalidRegister = register.copy(deliveredAt = null)
+
+                shouldThrow<CoreException> {
+                    reviewStore.register(invalidRegister)
+                }.errorCode shouldBe ReviewErrorCode.ORDER_NOT_DELIVERED
+
+                verify(exactly = 0) { reviewRepository.save(any()) }
+            }
+
+            test("리뷰 작성 기한이 지나면 TOO_LATE 예외가 발생한다.") {
+                val deliveredAt = timeProvider.now().minusDays(Review.MAX_WRITTEN_DATE + 1)
+                val expiredRegister = register.copy(deliveredAt = deliveredAt)
+
+                shouldThrow<CoreException> {
+                    reviewStore.register(expiredRegister)
+                }.errorCode shouldBe ReviewErrorCode.TOO_LATE
+
+                verify(exactly = 0) { reviewRepository.save(any()) }
+            }
+
+            test("이미 작성된 리뷰가 있으면 ALREADY_WRITE 예외가 발생한다.") {
+                val deliveredAt = timeProvider.now()
+                val register = register.copy(deliveredAt = deliveredAt)
+                every { reviewReader.existsByUserIdAndOrderItemId(register.userId, register.orderItemId) } returns true
+
+                shouldThrow<CoreException> {
+                    reviewStore.register(register)
+                }.errorCode shouldBe ReviewErrorCode.ALREADY_WRITE
+
+                verify(exactly = 0) { reviewRepository.save(any()) }
+            }
         }
 
-        test("리뷰 작성 기한이 지나면 TOO_LATE 예외가 발생한다.") {
-            val deliveredAt = timeProvider.now().minusDays(Review.MAX_WRITTEN_DATE + 1)
-            val expiredRegister = register.copy(deliveredAt = deliveredAt)
+        context("update") {
+            val reviewId = 1L
+            val ownerUserId = 100L
+            val command = ReviewUpdater(
+                id = reviewId,
+                userId = ownerUserId,
+                rating = 4,
+                content = "수정된 리뷰입니다.",
+            )
 
-            shouldThrow<CoreException> {
-                reviewStore.register(expiredRegister)
-            }.errorCode shouldBe ReviewErrorCode.TOO_LATE
+            test("리뷰 작성자가 맞으면 정상적으로 업데이트된다") {
+                val review = mockk<Review>(relaxed = true) {
+                    every { userId } returns ownerUserId
+                }
 
-            verify(exactly = 0) { reviewRepository.save(any()) }
+                every { reviewReader.getReviewById(reviewId) } returns review
+                every { review.update(command) } just Runs
+
+                reviewStore.update(command)
+
+                verify(exactly = 1) { review.update(command) }
+            }
+
+            test("리뷰 작성자가 아니면 UNAUTHORIZED_REVIEW_UPDATE 예외가 발생한다") {
+                val review = mockk<Review> {
+                    every { userId } returns ownerUserId
+                }
+                every { reviewReader.getReviewById(reviewId) } returns review
+                val unauthorizedCommand = command.copy(userId = ownerUserId + 1)
+
+                shouldThrow<CoreException> {
+                    reviewStore.update(unauthorizedCommand)
+                }.errorCode shouldBe ReviewErrorCode.UNAUTHORIZED_REVIEW_UPDATE
+            }
         }
-
-        test("이미 작성된 리뷰가 있으면 ALREADY_WRITE 예외가 발생한다.") {
-            val deliveredAt = timeProvider.now()
-            val register = register.copy(deliveredAt = deliveredAt)
-            every { reviewReader.existsByUserIdAndOrderItemId(register.userId, register.orderItemId) } returns true
-
-            shouldThrow<CoreException> {
-                reviewStore.register(register)
-            }.errorCode shouldBe ReviewErrorCode.ALREADY_WRITE
-
-            verify(exactly = 0) { reviewRepository.save(any()) }
-        }
-    }
-})
+    },
+)

--- a/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ReviewControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ReviewControllerRestDocTest.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.review.interfaces
 import com.fastcampus.commerce.restdoc.documentation
 import com.fastcampus.commerce.review.application.ReviewCommandService
 import com.fastcampus.commerce.review.interfaces.request.RegisterReviewApiRequest
+import com.fastcampus.commerce.review.interfaces.request.UpdateReviewApiRequest
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
@@ -69,6 +70,45 @@ class ReviewControllerRestDocTest : DescribeSpec() {
 
                     responseBody {
                         field("data.reviewId", "생성된 리뷰 아이디", 10)
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
+
+        describe("PUT /reviews/{reviewId} - 리뷰 수정") {
+            val summary = "리뷰를 수정할 수 있다."
+
+            it("리뷰를 수정할 수 있다.") {
+                val reviewId = 10L
+                val userId = 1L
+                val request = UpdateReviewApiRequest(
+                    rating = 3,
+                    content = "좋습니다.",
+                )
+
+                every { reviewCommandService.updateReview(userId, reviewId, request.toServiceRequest()) } returns reviewId
+
+                documentation(
+                    identifier = "리뷰_수정_성공",
+                    tag = tag,
+                    summary = summary,
+                ) {
+                    requestLine(HttpMethod.PUT, "/reviews/{reviewId}") {
+                        pathVariable("reviewId", "리뷰 아이디", reviewId)
+                    }
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    requestBody {
+                        field("rating", "별점", request.rating)
+                        field("content", "리뷰 내용", request.content)
+                    }
+
+                    responseBody {
+                        field("data.reviewId", "수저된 리뷰 아이디", reviewId.toInt())
                         ignoredField("error")
                     }
                 }

--- a/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ReviewControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ReviewControllerRestDocTest.kt
@@ -108,7 +108,7 @@ class ReviewControllerRestDocTest : DescribeSpec() {
                     }
 
                     responseBody {
-                        field("data.reviewId", "수저된 리뷰 아이디", reviewId.toInt())
+                        field("data.reviewId", "수정된 리뷰 아이디", reviewId.toInt())
                         ignoredField("error")
                     }
                 }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
리뷰 수정 API 추가
---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #42 

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->