### PR TITLE
feat(cart) : 장바구니 상품 수정 기능(#18)

### DIFF
--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -6,6 +6,8 @@ info:
 servers:
 - url: http://localhost:8080
 tags:
+- name: Cart
+  description: 장바구니 API
 - name: Review
   description: 사용자 리뷰 API
 - name: Admin-File
@@ -177,6 +179,54 @@ paths:
                     {
                       "data" : {
                         "message" : "OK"
+                      },
+                      "error" : null
+                    }
+  /cart/items:
+    patch:
+      tags:
+      - Cart
+      summary: 장바구니 내 상품의 수량을 변경할 수 있다.
+      operationId: 장바구니_상품_수정_성공
+      parameters:
+      - name: Authorization
+        in: header
+        description: Authorization
+        required: true
+        schema:
+          type: string
+        example: Bearer sample-token
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/cart-items-408437586"
+            examples:
+              장바구니_상품_수정_성공:
+                value: |-
+                  {
+                    "cartId" : 1,
+                    "userId" : 1,
+                    "productId" : 1,
+                    "quantity" : 100
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cart-items-1117620401"
+              examples:
+                장바구니_상품_수정_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "userId" : 1,
+                        "productId" : 1,
+                        "quantity" : 80,
+                        "stockQuantity" : 80,
+                        "requiresQuantityAdjustment" : true
                       },
                       "error" : null
                     }
@@ -357,17 +407,6 @@ paths:
                     }
 components:
   schemas:
-    admin-products9820101:
-      type: object
-      properties:
-        data:
-          required:
-          - productId
-          type: object
-          properties:
-            productId:
-              type: number
-              description: 생성된 상품 아이디
     files-presigned-url-2064193514:
       type: object
       properties:
@@ -387,26 +426,6 @@ components:
             key:
               type: string
               description: S3 Object Key
-    reviews1890941445:
-      required:
-      - content
-      - orderItemId
-      - orderNumber
-      - rating
-      type: object
-      properties:
-        orderNumber:
-          type: string
-          description: 주문번호
-        orderItemId:
-          type: number
-          description: 주문 아이템 아이디
-        rating:
-          type: number
-          description: 별점
-        content:
-          type: string
-          description: 리뷰 내용
     admin-products-productId-1789436874:
       required:
       - cupSizeId
@@ -454,17 +473,6 @@ components:
             reviewId:
               type: number
               description: 생성된 리뷰 아이디
-    admin-products-productId1686665306:
-      type: object
-      properties:
-        data:
-          required:
-          - message
-          type: object
-          properties:
-            message:
-              type: string
-              description: 응답 메시지
     reviews-reviewId480882763:
       required:
       - content
@@ -477,6 +485,134 @@ components:
         content:
           type: string
           description: 리뷰 내용
+    cart-items-408437586:
+      required:
+      - cartId
+      - productId
+      - quantity
+      - userId
+      type: object
+      properties:
+        quantity:
+          type: number
+          description: 수량
+        productId:
+          type: number
+          description: 상품 아이디
+        cartId:
+          type: number
+          description: 카트 아이디
+        userId:
+          type: number
+          description: 유저 아이디
+    files-presigned-url-1375438577:
+      required:
+      - contentType
+      - domainContext
+      - domainType
+      - fileName
+      - fileSize
+      type: object
+      properties:
+        domainContext:
+          type: string
+          description: 파일 컨텍스트(thumbnail/detailImage 고정)
+        fileName:
+          type: string
+          description: 파일명
+        domainType:
+          type: string
+          description: 도메인 타입(PRODUCT 고정)
+        fileSize:
+          type: number
+          description: 파일 크기(Byte)
+        contextId:
+          type: string
+          description: 업로드 세션 ID
+          nullable: true
+        contentType:
+          type: string
+          description: 파일 Content-Type
+    cart-items-1117620401:
+      type: object
+      properties:
+        data:
+          required:
+          - productId
+          - quantity
+          - requiresQuantityAdjustment
+          - stockQuantity
+          - userId
+          type: object
+          properties:
+            quantity:
+              type: number
+              description: 수량
+            productId:
+              type: number
+              description: 카트 아이디
+            requiresQuantityAdjustment:
+              type: boolean
+              description: 수량 변경 여부
+            stockQuantity:
+              type: number
+              description: 재고 수량
+            userId:
+              type: number
+              description: 유저 아이디
+    reviews-reviewId-215377401:
+      type: object
+      properties:
+        data:
+          required:
+          - reviewId
+          type: object
+          properties:
+            reviewId:
+              type: number
+              description: 수정된 리뷰 아이디
+    admin-products9820101:
+      type: object
+      properties:
+        data:
+          required:
+          - productId
+          type: object
+          properties:
+            productId:
+              type: number
+              description: 생성된 상품 아이디
+    reviews1890941445:
+      required:
+      - content
+      - orderItemId
+      - orderNumber
+      - rating
+      type: object
+      properties:
+        orderNumber:
+          type: string
+          description: 주문번호
+        orderItemId:
+          type: number
+          description: 주문 아이템 아이디
+        rating:
+          type: number
+          description: 별점
+        content:
+          type: string
+          description: 리뷰 내용
+    admin-products-productId1686665306:
+      type: object
+      properties:
+        data:
+          required:
+          - message
+          type: object
+          properties:
+            message:
+              type: string
+              description: 응답 메시지
     admin-products-247955186:
       required:
       - cupSizeId
@@ -526,34 +662,6 @@ components:
               label:
                 type: string
                 description: 판매상태
-    files-presigned-url-1375438577:
-      required:
-      - contentType
-      - domainContext
-      - domainType
-      - fileName
-      - fileSize
-      type: object
-      properties:
-        domainContext:
-          type: string
-          description: 파일 컨텍스트(thumbnail/detailImage 고정)
-        fileName:
-          type: string
-          description: 파일명
-        domainType:
-          type: string
-          description: 도메인 타입(PRODUCT 고정)
-        fileSize:
-          type: number
-          description: 파일 크기(Byte)
-        contextId:
-          type: string
-          description: 업로드 세션 ID
-          nullable: true
-        contentType:
-          type: string
-          description: 파일 Content-Type
     admin-products-productId-1712578160:
       type: object
       properties:
@@ -565,14 +673,3 @@ components:
             productId:
               type: number
               description: 수정된 상품 아이디
-    reviews-reviewId-215377401:
-      type: object
-      properties:
-        data:
-          required:
-          - reviewId
-          type: object
-          properties:
-            reviewId:
-              type: number
-              description: 수정된 리뷰 아이디

--- a/docs/api/tag-descriptions.yml
+++ b/docs/api/tag-descriptions.yml
@@ -1,3 +1,4 @@
+Cart: 장바구니 API
 Review: 사용자 리뷰 API
 Admin-File: 관리자 파일 업로드 API
 Admin-Product: 관리자 상품 API

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -64,9 +64,9 @@ class CartItemService(
     }
 
     @Transactional
-    fun updateCartItem(cartItemId: Long, request: CartUpdateRequest): CartUpdateResponse {
+    fun updateCartItem(request: CartUpdateRequest): CartUpdateResponse {
         var requireQuantityAdjustment = false
-        val cartItem = cartItemRepository.findByUserIdAndId(request.userId, cartItemId)
+        val cartItem = cartItemRepository.findByUserIdAndId(request.userId, request.cartId)
             ?: throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
 
         val inventory = productReader.getInventoryByProductId(cartItem.productId)

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -1,8 +1,12 @@
 package com.fastcampus.commerce.cart.application
 
 import com.fastcampus.commerce.cart.domain.entity.CartItem
+import com.fastcampus.commerce.cart.domain.error.CartErrorCode
 import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
 import com.fastcampus.commerce.cart.interfaces.CartCreateResponse
+import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
+import com.fastcampus.commerce.cart.interfaces.CartUpdateResponse
+import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.service.ProductReader
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -56,6 +60,32 @@ class CartItemService(
             quantity = finalQuantity,
             stockQuantity = stockQuantity,
             requiresQuantityAdjustment = requiresQuantityAdjustment,
+        )
+    }
+
+    @Transactional
+    fun updateCartItem(cartItemId: Long, request: CartUpdateRequest): CartUpdateResponse {
+        var requireQuantityAdjustment = false
+        val cartItem = cartItemRepository.findByUserIdAndId(request.userId,cartItemId)
+            ?: throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
+
+        val inventory = productReader.getInventoryByProductId(cartItem.productId)
+
+        if (request.quantity > inventory.quantity) {
+            cartItem.quantity = inventory.quantity
+            requireQuantityAdjustment = true
+        } else {
+            cartItem.quantity = request.quantity
+        }
+
+        cartItemRepository.save(cartItem)
+
+        return CartUpdateResponse(
+            userId = request.userId,
+            productId = cartItem.id!!,
+            quantity = cartItem.quantity,
+            stockQuantity = inventory.quantity,
+            requiresQuantityAdjustment =requireQuantityAdjustment
         )
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -66,7 +66,7 @@ class CartItemService(
     @Transactional
     fun updateCartItem(cartItemId: Long, request: CartUpdateRequest): CartUpdateResponse {
         var requireQuantityAdjustment = false
-        val cartItem = cartItemRepository.findByUserIdAndId(request.userId,cartItemId)
+        val cartItem = cartItemRepository.findByUserIdAndId(request.userId, cartItemId)
             ?: throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
 
         val inventory = productReader.getInventoryByProductId(cartItem.productId)
@@ -85,7 +85,7 @@ class CartItemService(
             productId = cartItem.id!!,
             quantity = cartItem.quantity,
             stockQuantity = inventory.quantity,
-            requiresQuantityAdjustment =requireQuantityAdjustment
+            requiresQuantityAdjustment = requireQuantityAdjustment,
         )
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/domain/error/CartErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/domain/error/CartErrorCode.kt
@@ -11,4 +11,3 @@ enum class CartErrorCode(
     EMPTY_PRODUCT_IDS("CRT-001", "Product IDs cannot be empty", LogLevel.WARN),
     CART_ITEMS_NOT_FOUND("CRT-002", "No cart items found for the given product IDs", LogLevel.WARN),
 }
-

--- a/src/main/kotlin/com/fastcampus/commerce/cart/domain/error/CartErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/domain/error/CartErrorCode.kt
@@ -1,0 +1,14 @@
+package com.fastcampus.commerce.cart.domain.error
+
+import com.fastcampus.commerce.common.error.ErrorCode
+import com.fastcampus.commerce.common.error.LogLevel
+
+enum class CartErrorCode(
+    override val code: String,
+    override val message: String,
+    override val logLevel: LogLevel,
+) : ErrorCode {
+    EMPTY_PRODUCT_IDS("CRT-001", "Product IDs cannot be empty", LogLevel.WARN),
+    CART_ITEMS_NOT_FOUND("CRT-002", "No cart items found for the given product IDs", LogLevel.WARN),
+}
+

--- a/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
@@ -9,4 +9,6 @@ interface CartItemRepository : JpaRepository<CartItem, Long> {
     fun findByUserId(userId: Long): List<CartItem>
 
     fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
+
+    fun findByUserIdAndId(userId: Long, cartItemId: Long) : CartItem?
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
@@ -10,5 +10,5 @@ interface CartItemRepository : JpaRepository<CartItem, Long> {
 
     fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
 
-    fun findByUserIdAndId(userId: Long, cartItemId: Long) : CartItem?
+    fun findByUserIdAndId(userId: Long, cartItemId: Long): CartItem?
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -22,10 +22,9 @@ class CartItemController(
 
     @PatchMapping("/cart/items")
     fun updateCartItem(
-        @RequestParam cartItemId: Long,
         @RequestBody request: CartUpdateRequest,
     ): CartUpdateResponse {
-        val cartResponse = cartItemService.updateCartItem(cartItemId, request)
+        val cartResponse = cartItemService.updateCartItem(request)
         return cartResponse
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.cart.interfaces
 
 import com.fastcampus.commerce.cart.application.CartItemService
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -17,5 +18,14 @@ class CartItemController(
     ): CartCreateResponse {
         val response = cartItemService.addToCart(userId, request.productId, request.quantity)
         return response
+    }
+
+    @PatchMapping("/cart/items")
+    fun updateCartItem(
+        @RequestParam cartItemId: Long,
+        @RequestBody request: CartUpdateRequest,
+    ) : CartUpdateResponse   {
+        val cartResponse = cartItemService.updateCartItem(cartItemId, request)
+        return cartResponse
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -24,7 +24,7 @@ class CartItemController(
     fun updateCartItem(
         @RequestParam cartItemId: Long,
         @RequestBody request: CartUpdateRequest,
-    ) : CartUpdateResponse   {
+    ): CartUpdateResponse {
         val cartResponse = cartItemService.updateCartItem(cartItemId, request)
         return cartResponse
     }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -10,3 +10,17 @@ data class CartCreateResponse(
     val stockQuantity: Int,
     val requiresQuantityAdjustment: Boolean,
 )
+
+data class CartUpdateRequest(
+    val userId: Long,
+    val productId: Long,
+    val quantity: Int,
+)
+
+data class CartUpdateResponse(
+    val userId: Long,
+    val productId: Long,
+    val quantity: Int,
+    val stockQuantity: Int,
+    val requiresQuantityAdjustment: Boolean,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -12,6 +12,7 @@ data class CartCreateResponse(
 )
 
 data class CartUpdateRequest(
+    val cartId: Long,
     val userId: Long,
     val productId: Long,
     val quantity: Int,

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -2,9 +2,12 @@ package com.fastcampus.commerce.cart.application
 
 import com.fastcampus.commerce.cart.domain.entity.CartItem
 import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
+import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.service.ProductReader
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
@@ -12,6 +15,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import java.util.Optional
 
 class CartItemServiceTest {
     private lateinit var cartItemRepository: CartItemRepository
@@ -115,4 +119,79 @@ class CartItemServiceTest {
         assertEquals(10, result.stockQuantity)
         assertEquals(true, result.requiresQuantityAdjustment)
     }
+
+    @Test
+    fun `장바구니 아이템 수량 업데이트 - 재고 수량 이내`() {
+        // Given
+        val userId = 1L
+        val cartItemId = 1L
+        val productId = 2L
+        val requestQuantity = 5
+        val inventoryQuantity = 10
+
+        val cartItem = CartItem(userId, productId, 3)
+        cartItem.id = cartItemId
+
+        val inventory = Inventory(productId, inventoryQuantity)
+        inventory.id = productId
+
+        val request = CartUpdateRequest(userId, productId, requestQuantity)
+
+        `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
+        `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
+        `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
+
+        // When
+        val result = cartItemService.updateCartItem(cartItemId, request)
+
+        // Then
+        verify(cartItemRepository).save(any(CartItem::class.java))
+
+        // cartItem의 quantity가 실제로 변경되었는지 확인
+        assertEquals(requestQuantity, cartItem.quantity)
+
+        assertEquals(userId, result.userId)
+        assertEquals(cartItemId, result.productId)
+        assertEquals(requestQuantity, result.quantity)
+        assertEquals(inventoryQuantity, result.stockQuantity)
+        assertFalse(result.requiresQuantityAdjustment)
+    }
+
+    @Test
+    fun `장바구니 아이템 수량 업데이트 - 재고 수량 초과`() {
+        // Given
+        val userId = 1L
+        val cartItemId = 1L
+        val productId = 2L
+        val requestQuantity = 15
+        val inventoryQuantity = 10
+
+        val cartItem = CartItem(userId, productId, 3)
+        cartItem.id = cartItemId
+
+        val inventory = Inventory(productId, inventoryQuantity)
+        inventory.id = productId
+
+        val request = CartUpdateRequest(userId, productId, requestQuantity)
+
+        `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
+        `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
+        `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
+
+        // When
+        val result = cartItemService.updateCartItem(cartItemId, request)
+
+        // Then
+        verify(cartItemRepository).save(any(CartItem::class.java))
+
+        // 재고 초과시 inventory quantity로 조정되었는지 확인
+        assertEquals(inventoryQuantity, cartItem.quantity)
+
+        assertEquals(userId, result.userId)
+        assertEquals(cartItemId, result.productId)
+        assertEquals(inventoryQuantity, result.quantity)
+        assertEquals(inventoryQuantity, result.stockQuantity)
+        assertTrue(result.requiresQuantityAdjustment)
+    }
+
 }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -134,7 +134,7 @@ class CartItemServiceTest {
         val inventory = Inventory(productId, inventoryQuantity)
         inventory.id = productId
 
-        val request = CartUpdateRequest(cartItemId,userId, productId, requestQuantity)
+        val request = CartUpdateRequest(cartItemId, userId, productId, requestQuantity)
 
         `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
         `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
@@ -171,7 +171,7 @@ class CartItemServiceTest {
         val inventory = Inventory(productId, inventoryQuantity)
         inventory.id = productId
 
-        val request = CartUpdateRequest(cartItemId,userId, productId, requestQuantity)
+        val request = CartUpdateRequest(cartItemId, userId, productId, requestQuantity)
 
         `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
         `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -134,14 +134,14 @@ class CartItemServiceTest {
         val inventory = Inventory(productId, inventoryQuantity)
         inventory.id = productId
 
-        val request = CartUpdateRequest(userId, productId, requestQuantity)
+        val request = CartUpdateRequest(cartItemId,userId, productId, requestQuantity)
 
         `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
         `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
         `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
 
         // When
-        val result = cartItemService.updateCartItem(cartItemId, request)
+        val result = cartItemService.updateCartItem(request)
 
         // Then
         verify(cartItemRepository).save(any(CartItem::class.java))
@@ -171,14 +171,14 @@ class CartItemServiceTest {
         val inventory = Inventory(productId, inventoryQuantity)
         inventory.id = productId
 
-        val request = CartUpdateRequest(userId, productId, requestQuantity)
+        val request = CartUpdateRequest(cartItemId,userId, productId, requestQuantity)
 
         `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
         `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
         `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
 
         // When
-        val result = cartItemService.updateCartItem(cartItemId, request)
+        val result = cartItemService.updateCartItem(request)
 
         // Then
         verify(cartItemRepository).save(any(CartItem::class.java))

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -15,7 +15,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import java.util.Optional
 
 class CartItemServiceTest {
     private lateinit var cartItemRepository: CartItemRepository
@@ -193,5 +192,4 @@ class CartItemServiceTest {
         assertEquals(inventoryQuantity, result.stockQuantity)
         assertTrue(result.requiresQuantityAdjustment)
     }
-
 }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -28,6 +28,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
 
     @MockkBean
     lateinit var cartItemService: CartItemService
+
     @MockkBean
     lateinit var productReader: ProductReader
 
@@ -50,7 +51,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     productId = productId,
                     quantity = 100,
                     userId = userId,
-                    cartId = cartId
+                    cartId = cartId,
                 )
 
                 val inventory = Inventory(
@@ -88,9 +89,8 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
                     }
 
-
                     requestBody {
-                        field("cartId","카트 아이디",request.cartId)
+                        field("cartId", "카트 아이디", request.cartId)
                         field("userId", "유저 아이디", request.userId)
                         field("productId", "상품 아이디", request.productId)
                         field("quantity", "수량", request.quantity)

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -1,0 +1,106 @@
+package com.fastcampus.commerce.cart.interfaces
+
+import com.fastcampus.commerce.admin.product.interfaces.AdminProductControllerRestDocTest
+import com.fastcampus.commerce.cart.application.CartItemService
+import com.fastcampus.commerce.product.domain.entity.Inventory
+import com.fastcampus.commerce.product.domain.service.ProductReader
+import com.fastcampus.commerce.restdoc.documentation
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.restassured.module.mockmvc.RestAssuredMockMvc
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.MockMvc
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@WebMvcTest(CartItemController::class)
+class CartItemControllerRestDocTest : DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var cartItemService: CartItemService
+    lateinit var productReader: ProductReader
+
+    val tag = "Cart"
+    val privateResource = true
+
+    init {
+        beforeSpec {
+            RestAssuredMockMvc.mockMvc(mockMvc)
+        }
+
+        describe("PATCH /cart/item - 장바구니 내의 상품 수량 변경"){
+            val summary = "장바구니 내 상품의 수량을 변경할 수 있다."
+            it("장바구니 내 상품의 수량을 변경할 수 있다."){
+                val userId = 1L
+                val productId = 1L
+                var finalQuantity = 1
+                val request = CartUpdateRequest(
+                    productId = productId,
+                    quantity = 100,
+                    userId = userId,
+                )
+
+                val inventory = Inventory(
+                    productId = productId,
+                    quantity = 80
+                )
+
+                every{productReader.getInventoryByProductId(productId)} returns inventory
+
+                if(request.quantity > inventory.quantity){
+                    finalQuantity = inventory.quantity
+                } else{
+                    finalQuantity = request.quantity
+                }
+
+                val response = CartUpdateResponse(
+                    userId = userId,
+                    productId = productId,
+                    quantity = finalQuantity,
+                    stockQuantity = inventory.quantity,
+                    requiresQuantityAdjustment = true,
+                )
+
+                every { cartItemService.updateCartItem(userId,  request) } returns response
+
+                documentation(
+                    identifier = "상품_수정_성공",
+                    tag = tag,
+                    summary = summary,
+                    privateResource = privateResource,
+                ) {
+                    requestLine(HttpMethod.PATCH, "/cart/items")
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    requestBody{
+                        field("userId","유저 아이디", request.userId)
+                        field("productId","카트 아이디", request.productId)
+                        field("quantity", "수량",request.quantity)
+                    }
+
+                    responseBody {
+                        field("productId","카트 아이디",response.productId)
+                        field("userId","유저 아이디",response.userId)
+                        field("quantity","수량",response.quantity)
+                        field("stockQuantity","재고 수량",response.stockQuantity)
+                        field("requiresQuantityAdjustment","수량 변경 여부",response.requiresQuantityAdjustment)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -1,6 +1,5 @@
 package com.fastcampus.commerce.cart.interfaces
 
-import com.fastcampus.commerce.admin.product.interfaces.AdminProductControllerRestDocTest
 import com.fastcampus.commerce.cart.application.CartItemService
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.service.ProductReader
@@ -39,9 +38,9 @@ class CartItemControllerRestDocTest : DescribeSpec() {
             RestAssuredMockMvc.mockMvc(mockMvc)
         }
 
-        describe("PATCH /cart/item - 장바구니 내의 상품 수량 변경"){
+        describe("PATCH /cart/item - 장바구니 내의 상품 수량 변경") {
             val summary = "장바구니 내 상품의 수량을 변경할 수 있다."
-            it("장바구니 내 상품의 수량을 변경할 수 있다."){
+            it("장바구니 내 상품의 수량을 변경할 수 있다.") {
                 val userId = 1L
                 val productId = 1L
                 var finalQuantity = 1
@@ -53,14 +52,14 @@ class CartItemControllerRestDocTest : DescribeSpec() {
 
                 val inventory = Inventory(
                     productId = productId,
-                    quantity = 80
+                    quantity = 80,
                 )
 
-                every{productReader.getInventoryByProductId(productId)} returns inventory
+                every { productReader.getInventoryByProductId(productId) } returns inventory
 
-                if(request.quantity > inventory.quantity){
+                if (request.quantity > inventory.quantity) {
                     finalQuantity = inventory.quantity
-                } else{
+                } else {
                     finalQuantity = request.quantity
                 }
 
@@ -72,7 +71,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     requiresQuantityAdjustment = true,
                 )
 
-                every { cartItemService.updateCartItem(userId,  request) } returns response
+                every { cartItemService.updateCartItem(userId, request) } returns response
 
                 documentation(
                     identifier = "상품_수정_성공",
@@ -86,18 +85,18 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
                     }
 
-                    requestBody{
-                        field("userId","유저 아이디", request.userId)
-                        field("productId","카트 아이디", request.productId)
-                        field("quantity", "수량",request.quantity)
+                    requestBody {
+                        field("userId", "유저 아이디", request.userId)
+                        field("productId", "카트 아이디", request.productId)
+                        field("quantity", "수량", request.quantity)
                     }
 
                     responseBody {
-                        field("productId","카트 아이디",response.productId)
-                        field("userId","유저 아이디",response.userId)
-                        field("quantity","수량",response.quantity)
-                        field("stockQuantity","재고 수량",response.stockQuantity)
-                        field("requiresQuantityAdjustment","수량 변경 여부",response.requiresQuantityAdjustment)
+                        field("productId", "카트 아이디", response.productId)
+                        field("userId", "유저 아이디", response.userId)
+                        field("quantity", "수량", response.quantity)
+                        field("stockQuantity", "재고 수량", response.stockQuantity)
+                        field("requiresQuantityAdjustment", "수량 변경 여부", response.requiresQuantityAdjustment)
                     }
                 }
             }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -77,7 +77,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                 every { cartItemService.updateCartItem(request) } returns response
 
                 documentation(
-                    identifier = "상품_수정_성공",
+                    identifier = "장바구니_상품_수정_성공",
                     tag = tag,
                     summary = summary,
                     privateResource = privateResource,

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -28,6 +28,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
 
     @MockkBean
     lateinit var cartItemService: CartItemService
+    @MockkBean
     lateinit var productReader: ProductReader
 
     val tag = "Cart"
@@ -44,10 +45,12 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                 val userId = 1L
                 val productId = 1L
                 var finalQuantity = 1
+                val cartId = 1L
                 val request = CartUpdateRequest(
                     productId = productId,
                     quantity = 100,
                     userId = userId,
+                    cartId = cartId
                 )
 
                 val inventory = Inventory(
@@ -71,7 +74,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     requiresQuantityAdjustment = true,
                 )
 
-                every { cartItemService.updateCartItem(userId, request) } returns response
+                every { cartItemService.updateCartItem(request) } returns response
 
                 documentation(
                     identifier = "상품_수정_성공",
@@ -85,18 +88,21 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
                     }
 
+
                     requestBody {
+                        field("cartId","카트 아이디",request.cartId)
                         field("userId", "유저 아이디", request.userId)
-                        field("productId", "카트 아이디", request.productId)
+                        field("productId", "상품 아이디", request.productId)
                         field("quantity", "수량", request.quantity)
                     }
 
                     responseBody {
-                        field("productId", "카트 아이디", response.productId)
-                        field("userId", "유저 아이디", response.userId)
-                        field("quantity", "수량", response.quantity)
-                        field("stockQuantity", "재고 수량", response.stockQuantity)
-                        field("requiresQuantityAdjustment", "수량 변경 여부", response.requiresQuantityAdjustment)
+                        field("data.productId", "카트 아이디", response.productId.toInt())
+                        field("data.userId", "유저 아이디", response.userId.toInt())
+                        field("data.quantity", "수량", response.quantity)
+                        field("data.stockQuantity", "재고 수량", response.stockQuantity)
+                        field("data.requiresQuantityAdjustment", "수량 변경 여부", response.requiresQuantityAdjustment)
+                        ignoredField("error")
                     }
                 }
             }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

장바구니 상품 수정 API 구현을 위한 백엔드 로직 추가

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

- PATCH /cart/item 엔드포인트 추가 

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

- openapi3.yml 파일에 제가 작업한 부분 외의 변경점이 있어 이부분 확인이 필요합니다.

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->

#18 

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->