### PR TITLE
[feat] 상품 리뷰 관련 API 추가

### DIFF
--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -321,6 +321,91 @@ paths:
                       },
                       "error" : null
                     }
+  /products/{productId}/reviews:
+    get:
+      tags:
+      - Review
+      summary: 상품에 등록된 리뷰 목록 조회
+      operationId: 상품_리뷰목록_조회_성공
+      parameters:
+      - name: productId
+        in: path
+        description: 상품 아이디
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: "페이지(기본 값: 1)"
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/products-productId-reviews-352554938"
+              examples:
+                상품_리뷰목록_조회_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "content" : [ {
+                          "reviewId" : 1,
+                          "rating" : 5,
+                          "content" : "아주 만족해요",
+                          "createdAt" : "2025-06-01T12:00",
+                          "adminReply" : {
+                            "content" : "감사합니다",
+                            "createdAt" : "2025-06-01T12:00"
+                          }
+                        } ],
+                        "page" : 1,
+                        "size" : 10,
+                        "totalPages" : 2,
+                        "totalElements" : 11
+                      },
+                      "error" : null
+                    }
+  /products/{productId}/reviews/rating:
+    get:
+      tags:
+      - Review
+      summary: 상품에 등록된 리뷰 별점 통계 조회
+      operationId: 상품_리뷰별점통계_조회_성공
+      parameters:
+      - name: productId
+        in: path
+        description: 상품 아이디
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/products-productId-reviews-rating-66572293"
+              examples:
+                상품_리뷰별점통계_조회_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "averageRating" : 3.5,
+                        "totalCount" : 10,
+                        "ratingDistribution" : {
+                          "oneStarCount" : 2,
+                          "twoStarsCount" : 3,
+                          "threeStarsCount" : 5,
+                          "fourStarsCount" : 1,
+                          "fiveStarsCount" : 8
+                        }
+                      },
+                      "error" : null
+                    }
   /reviews:
     post:
       tags:
@@ -656,6 +741,45 @@ components:
             message:
               type: string
               description: 응답 메시지
+    products-productId-reviews-rating-66572293:
+      type: object
+      properties:
+        data:
+          required:
+          - averageRating
+          - totalCount
+          type: object
+          properties:
+            ratingDistribution:
+              required:
+              - fiveStarsCount
+              - fourStarsCount
+              - oneStarCount
+              - threeStarsCount
+              - twoStarsCount
+              type: object
+              properties:
+                oneStarCount:
+                  type: number
+                  description: 별점 1점 개수
+                twoStarsCount:
+                  type: number
+                  description: 별점 2점 개수
+                fiveStarsCount:
+                  type: number
+                  description: 별점 5점 개수
+                fourStarsCount:
+                  type: number
+                  description: 별점 4점 개수
+                threeStarsCount:
+                  type: number
+                  description: 별점 3점 개수
+            averageRating:
+              type: number
+              description: 평점
+            totalCount:
+              type: number
+              description: 리뷰 개수
     admin-products-247955186:
       required:
       - cupSizeId
@@ -724,6 +848,62 @@ components:
               label:
                 type: string
                 description: 판매상태
+    products-productId-reviews-352554938:
+      type: object
+      properties:
+        data:
+          required:
+          - page
+          - size
+          - totalElements
+          - totalPages
+          type: object
+          properties:
+            size:
+              type: number
+              description: 페이지 사이즈(기본값 10)
+            totalPages:
+              type: number
+              description: 전체 페이지 수
+            page:
+              type: number
+              description: 현재 페이지 (기본값 1)
+            content:
+              type: array
+              items:
+                required:
+                - content
+                - createdAt
+                - rating
+                - reviewId
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 리뷰 작성일
+                  rating:
+                    type: number
+                    description: 별점
+                  reviewId:
+                    type: number
+                    description: 리뷰 아이디
+                  adminReply:
+                    type: object
+                    properties:
+                      createdAt:
+                        type: string
+                        description: 관리자 답글 작성일
+                        nullable: true
+                      content:
+                        type: string
+                        description: 관리자 답글 내용
+                        nullable: true
+                  content:
+                    type: string
+                    description: 리뷰 내용
+            totalElements:
+              type: number
+              description: 총 수
     admin-products-productId-1712578160:
       type: object
       properties:

--- a/src/main/kotlin/com/fastcampus/commerce/common/response/PagedData.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/response/PagedData.kt
@@ -1,0 +1,23 @@
+package com.fastcampus.commerce.common.response
+
+import org.springframework.data.domain.Page
+
+data class PagedData<T> private constructor(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalPages: Int,
+    val totalElements: Long,
+) {
+    companion object {
+        fun <S> of(page: Page<S>): PagedData<S> {
+            return PagedData(
+                content = page.content,
+                page = page.number,
+                size = page.size,
+                totalPages = page.totalPages,
+                totalElements = page.totalElements,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/ProductReviewService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/ProductReviewService.kt
@@ -1,0 +1,17 @@
+package com.fastcampus.commerce.review.application
+
+import com.fastcampus.commerce.review.application.response.ProductReviewResponse
+import com.fastcampus.commerce.review.domain.repository.ProductReviewRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+
+@Service
+class ProductReviewService(
+    private val productReviewRepository: ProductReviewRepository,
+) {
+    fun getProductReviews(productId: Long, pageable: Pageable): Page<ProductReviewResponse> {
+        val productReviews = productReviewRepository.getProductReviews(productId, pageable)
+        return productReviews.map(ProductReviewResponse::from)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/ProductReviewService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/ProductReviewService.kt
@@ -1,6 +1,8 @@
 package com.fastcampus.commerce.review.application
 
+import com.fastcampus.commerce.review.application.response.ProductReviewRatingResponse
 import com.fastcampus.commerce.review.application.response.ProductReviewResponse
+import com.fastcampus.commerce.review.domain.model.ProductReviewRating
 import com.fastcampus.commerce.review.domain.repository.ProductReviewRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -13,5 +15,11 @@ class ProductReviewService(
     fun getProductReviews(productId: Long, pageable: Pageable): Page<ProductReviewResponse> {
         val productReviews = productReviewRepository.getProductReviews(productId, pageable)
         return productReviews.map(ProductReviewResponse::from)
+    }
+
+    fun getProductReviewRating(productId: Long): ProductReviewRatingResponse {
+        val productReviewRating: ProductReviewRating = productReviewRepository.getProductReviewRating(productId)
+            ?: ProductReviewRating.empty()
+        return ProductReviewRatingResponse.from(productReviewRating)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/response/ProductReviewRatingResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/response/ProductReviewRatingResponse.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.commerce.review.application.response
+
+import com.fastcampus.commerce.review.domain.model.ProductReviewRating
+
+data class ProductReviewRatingResponse(
+    val averageRating: Double,
+    val totalCount: Long,
+    val ratingDistribution: RatingDistributionResponse,
+) {
+    companion object {
+        fun from(response: ProductReviewRating) =
+            ProductReviewRatingResponse(
+                averageRating = response.average,
+                totalCount = response.totalCount,
+                ratingDistribution = RatingDistributionResponse(
+                    oneStarCount = response.oneStarCount,
+                    twoStarsCount = response.twoStarsCount,
+                    threeStarsCount = response.threeStarsCount,
+                    fourStarsCount = response.fourStarsCount,
+                    fiveStarsCount = response.fiveStarsCount,
+                ),
+            )
+    }
+}
+
+data class RatingDistributionResponse(
+    val oneStarCount: Int,
+    val twoStarsCount: Int,
+    val threeStarsCount: Int,
+    val fourStarsCount: Int,
+    val fiveStarsCount: Int,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/review/application/response/ProductReviewResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/application/response/ProductReviewResponse.kt
@@ -1,0 +1,37 @@
+package com.fastcampus.commerce.review.application.response
+
+import com.fastcampus.commerce.review.domain.model.AdminReply
+import com.fastcampus.commerce.review.domain.model.ProductReview
+import java.time.LocalDateTime
+
+data class ProductReviewResponse(
+    val reviewId: Long,
+    val rating: Int,
+    val content: String,
+    val createdAt: LocalDateTime,
+    val adminReply: AdminReplyResponse? = null,
+) {
+    companion object {
+        fun from(productReview: ProductReview): ProductReviewResponse =
+            ProductReviewResponse(
+                reviewId = productReview.reviewId,
+                rating = productReview.rating,
+                content = productReview.content,
+                createdAt = productReview.createdAt,
+                adminReply = productReview.adminReply?.let { AdminReplyResponse.from(it) },
+            )
+    }
+}
+
+data class AdminReplyResponse(
+    val content: String,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(adminReply: AdminReply): AdminReplyResponse =
+            AdminReplyResponse(
+                content = adminReply.content,
+                createdAt = adminReply.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ProductReview.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ProductReview.kt
@@ -1,0 +1,21 @@
+package com.fastcampus.commerce.review.domain.model
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class ProductReview
+    @QueryProjection
+    constructor(
+        val reviewId: Long,
+        val rating: Int,
+        val content: String,
+        val createdAt: LocalDateTime,
+        val adminReply: AdminReply? = null,
+    )
+
+data class AdminReply
+    @QueryProjection
+    constructor(
+        val content: String,
+        val createdAt: LocalDateTime,
+    )

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ProductReviewRating.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/model/ProductReviewRating.kt
@@ -1,0 +1,29 @@
+package com.fastcampus.commerce.review.domain.model
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class ProductReviewRating
+    @QueryProjection
+    constructor(
+        val average: Double,
+        val totalCount: Long,
+        val oneStarCount: Int,
+        val twoStarsCount: Int,
+        val threeStarsCount: Int,
+        val fourStarsCount: Int,
+        val fiveStarsCount: Int,
+    ) {
+        companion object {
+            fun empty(): ProductReviewRating {
+                return ProductReviewRating(
+                    average = 0.0,
+                    totalCount = 0L,
+                    oneStarCount = 0,
+                    twoStarsCount = 0,
+                    threeStarsCount = 0,
+                    fourStarsCount = 0,
+                    fiveStarsCount = 0,
+                )
+            }
+        }
+    }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ProductReviewRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ProductReviewRepository.kt
@@ -1,9 +1,12 @@
 package com.fastcampus.commerce.review.domain.repository
 
 import com.fastcampus.commerce.review.domain.model.ProductReview
+import com.fastcampus.commerce.review.domain.model.ProductReviewRating
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface ProductReviewRepository {
     fun getProductReviews(productId: Long, pageable: Pageable): Page<ProductReview>
+
+    fun getProductReviewRating(productId: Long): ProductReviewRating?
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ProductReviewRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/domain/repository/ProductReviewRepository.kt
@@ -1,0 +1,9 @@
+package com.fastcampus.commerce.review.domain.repository
+
+import com.fastcampus.commerce.review.domain.model.ProductReview
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ProductReviewRepository {
+    fun getProductReviews(productId: Long, pageable: Pageable): Page<ProductReview>
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ProductReviewRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ProductReviewRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.fastcampus.commerce.review.infrastructure
+
+import com.fastcampus.commerce.review.domain.entity.QReview.review
+import com.fastcampus.commerce.review.domain.entity.QReviewReply.reviewReply
+import com.fastcampus.commerce.review.domain.model.ProductReview
+import com.fastcampus.commerce.review.domain.model.QAdminReply
+import com.fastcampus.commerce.review.domain.model.QProductReview
+import com.fastcampus.commerce.review.domain.repository.ProductReviewRepository
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProductReviewRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : ProductReviewRepository {
+    override fun getProductReviews(productId: Long, pageable: Pageable): Page<ProductReview> {
+        val reviews = queryFactory
+            .select(
+                QProductReview(
+                    review.id,
+                    review.rating,
+                    review.content,
+                    review.createdAt,
+                    QAdminReply(reviewReply.content, reviewReply.createdAt),
+                ),
+            )
+            .from(review)
+            .leftJoin(reviewReply).on(review.id.eq(reviewReply.reviewId))
+            .where(review.productId.eq(productId))
+            .orderBy(review.createdAt.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageableExecutionUtils.getPage(reviews, pageable) {
+            queryFactory
+                .select(review.id.count())
+                .from(review)
+                .where(review.productId.eq(productId))
+                .fetchOne() ?: 0L
+        }
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ProductReviewRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/infrastructure/ProductReviewRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.fastcampus.commerce.review.infrastructure
 import com.fastcampus.commerce.review.domain.entity.QReview.review
 import com.fastcampus.commerce.review.domain.entity.QReviewReply.reviewReply
 import com.fastcampus.commerce.review.domain.model.ProductReview
+import com.fastcampus.commerce.review.domain.model.ProductReviewRating
 import com.fastcampus.commerce.review.domain.model.QAdminReply
 import com.fastcampus.commerce.review.domain.model.QProductReview
+import com.fastcampus.commerce.review.domain.model.QProductReviewRating
 import com.fastcampus.commerce.review.domain.repository.ProductReviewRepository
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
@@ -42,5 +44,23 @@ class ProductReviewRepositoryImpl(
                 .where(review.productId.eq(productId))
                 .fetchOne() ?: 0L
         }
+    }
+
+    override fun getProductReviewRating(productId: Long): ProductReviewRating? {
+        return queryFactory
+            .select(
+                QProductReviewRating(
+                    review.rating.avg().coalesce(0.0),
+                    review.count(),
+                    review.rating.`when`(1).then(1).otherwise(0).sumAggregate(),
+                    review.rating.`when`(2).then(1).otherwise(0).sumAggregate(),
+                    review.rating.`when`(3).then(1).otherwise(0).sumAggregate(),
+                    review.rating.`when`(4).then(1).otherwise(0).sumAggregate(),
+                    review.rating.`when`(5).then(1).otherwise(0).sumAggregate(),
+                ),
+            )
+            .from(review)
+            .where(review.productId.eq(productId))
+            .fetchOne()
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ProductReviewController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ProductReviewController.kt
@@ -1,0 +1,28 @@
+package com.fastcampus.commerce.review.interfaces
+
+import com.fastcampus.commerce.common.response.PagedData
+import com.fastcampus.commerce.review.application.ProductReviewService
+import com.fastcampus.commerce.review.application.response.ProductReviewResponse
+import com.fastcampus.commerce.review.interfaces.response.ProductReviewApiResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/products")
+@RestController
+class ProductReviewController(
+    private val productReviewService: ProductReviewService,
+) {
+    @GetMapping("/{productId}/reviews")
+    fun getProductReviews(
+        @PathVariable productId: Long,
+        @PageableDefault pageable: Pageable,
+    ): PagedData<ProductReviewApiResponse> {
+        val productReviews: Page<ProductReviewResponse> = productReviewService.getProductReviews(productId, pageable)
+        return PagedData.of(productReviews.map(ProductReviewApiResponse::from))
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ProductReviewController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/ProductReviewController.kt
@@ -2,8 +2,10 @@ package com.fastcampus.commerce.review.interfaces
 
 import com.fastcampus.commerce.common.response.PagedData
 import com.fastcampus.commerce.review.application.ProductReviewService
+import com.fastcampus.commerce.review.application.response.ProductReviewRatingResponse
 import com.fastcampus.commerce.review.application.response.ProductReviewResponse
 import com.fastcampus.commerce.review.interfaces.response.ProductReviewApiResponse
+import com.fastcampus.commerce.review.interfaces.response.ProductReviewRatingApiResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
@@ -24,5 +26,13 @@ class ProductReviewController(
     ): PagedData<ProductReviewApiResponse> {
         val productReviews: Page<ProductReviewResponse> = productReviewService.getProductReviews(productId, pageable)
         return PagedData.of(productReviews.map(ProductReviewApiResponse::from))
+    }
+
+    @GetMapping("/{productId}/reviews/rating")
+    fun getProductReviewRating(
+        @PathVariable productId: Long,
+    ): ProductReviewRatingApiResponse {
+        val reviewRating: ProductReviewRatingResponse = productReviewService.getProductReviewRating(productId)
+        return ProductReviewRatingApiResponse.from(reviewRating)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/ProductReviewApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/ProductReviewApiResponse.kt
@@ -1,0 +1,40 @@
+package com.fastcampus.commerce.review.interfaces.response
+
+import com.fastcampus.commerce.review.application.response.AdminReplyResponse
+import com.fastcampus.commerce.review.application.response.ProductReviewResponse
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+
+data class ProductReviewApiResponse(
+    val reviewId: Long,
+    val rating: Int,
+    val content: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+    val createdAt: LocalDateTime,
+    val adminReply: AdminReplyApiResponse? = null,
+) {
+    companion object {
+        fun from(it: ProductReviewResponse): ProductReviewApiResponse =
+            ProductReviewApiResponse(
+                reviewId = it.reviewId,
+                rating = it.rating,
+                content = it.content,
+                createdAt = it.createdAt,
+                adminReply = it.adminReply?.let(AdminReplyApiResponse::from),
+            )
+    }
+}
+
+data class AdminReplyApiResponse(
+    val content: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(adminReply: AdminReplyResponse) =
+            AdminReplyApiResponse(
+                content = adminReply.content,
+                createdAt = adminReply.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/ProductReviewRatingApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/review/interfaces/response/ProductReviewRatingApiResponse.kt
@@ -1,0 +1,38 @@
+package com.fastcampus.commerce.review.interfaces.response
+
+import com.fastcampus.commerce.review.application.response.ProductReviewRatingResponse
+import com.fastcampus.commerce.review.application.response.RatingDistributionResponse
+
+data class ProductReviewRatingApiResponse(
+    val averageRating: Double,
+    val totalCount: Long,
+    val ratingDistribution: RatingDistributionApiResponse,
+) {
+    companion object {
+        fun from(response: ProductReviewRatingResponse) =
+            ProductReviewRatingApiResponse(
+                averageRating = response.averageRating,
+                totalCount = response.totalCount,
+                ratingDistribution = RatingDistributionApiResponse.from(response.ratingDistribution),
+            )
+    }
+}
+
+data class RatingDistributionApiResponse(
+    val oneStarCount: Int,
+    val twoStarsCount: Int,
+    val threeStarsCount: Int,
+    val fourStarsCount: Int,
+    val fiveStarsCount: Int,
+) {
+    companion object {
+        fun from(response: RatingDistributionResponse) =
+            RatingDistributionApiResponse(
+                oneStarCount = response.oneStarCount,
+                twoStarsCount = response.twoStarsCount,
+                threeStarsCount = response.threeStarsCount,
+                fourStarsCount = response.fourStarsCount,
+                fiveStarsCount = response.fiveStarsCount,
+            )
+    }
+}

--- a/src/test/kotlin/com/fastcampus/commerce/review/application/ProductReviewServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/application/ProductReviewServiceTest.kt
@@ -1,0 +1,60 @@
+package com.fastcampus.commerce.review.application
+
+import com.fastcampus.commerce.review.application.response.ProductReviewResponse
+import com.fastcampus.commerce.review.domain.model.AdminReply
+import com.fastcampus.commerce.review.domain.model.ProductReview
+import com.fastcampus.commerce.review.domain.repository.ProductReviewRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDateTime
+
+class ProductReviewServiceTest : DescribeSpec({
+
+    val productReviewRepository = mockk<ProductReviewRepository>()
+    val productReviewService = ProductReviewService(productReviewRepository)
+
+    beforeTest {
+        clearAllMocks()
+    }
+
+    describe("상품 리뷰 목록 조회") {
+        it("상품에 등록된 리뷰 목록을 조회할 수 있다.") {
+            val productId = 1L
+            val pageable = PageRequest.of(1, 10)
+
+            val now = LocalDateTime.of(2025, 6, 1, 12, 0)
+            val productReviews = listOf(
+                ProductReview(
+                    reviewId = 1L,
+                    rating = 5,
+                    content = "아주 만족해요",
+                    createdAt = now,
+                    adminReply = AdminReply(
+                        content = "감사합니다",
+                        createdAt = now,
+                    ),
+                ),
+                ProductReview(
+                    reviewId = 2L,
+                    rating = 3,
+                    content = "좋습니다.",
+                    createdAt = now,
+                ),
+            )
+            val reviews = PageImpl(productReviews, pageable, productReviews.size.toLong())
+            every { productReviewRepository.getProductReviews(productId, pageable) } returns reviews
+
+            val result = productReviewService.getProductReviews(productId, pageable)
+
+            result.content shouldHaveSize productReviews.size
+            result.content[0] shouldBe ProductReviewResponse.from(productReviews[0])
+            result.content[1] shouldBe ProductReviewResponse.from(productReviews[1])
+        }
+    }
+})

--- a/src/test/kotlin/com/fastcampus/commerce/review/application/ProductReviewServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/application/ProductReviewServiceTest.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.review.application
 import com.fastcampus.commerce.review.application.response.ProductReviewResponse
 import com.fastcampus.commerce.review.domain.model.AdminReply
 import com.fastcampus.commerce.review.domain.model.ProductReview
+import com.fastcampus.commerce.review.domain.model.ProductReviewRating
 import com.fastcampus.commerce.review.domain.repository.ProductReviewRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -55,6 +56,46 @@ class ProductReviewServiceTest : DescribeSpec({
             result.content shouldHaveSize productReviews.size
             result.content[0] shouldBe ProductReviewResponse.from(productReviews[0])
             result.content[1] shouldBe ProductReviewResponse.from(productReviews[1])
+        }
+    }
+
+    describe("상품 리뷰 별점 통계") {
+        it("상품에 등록된 리뷰의 별점 통계를 조회할 수 있다.") {
+            val productId = 1L
+            val rating = ProductReviewRating(
+                average = 3.5,
+                totalCount = 10,
+                oneStarCount = 2,
+                twoStarsCount = 3,
+                threeStarsCount = 5,
+                fourStarsCount = 1,
+                fiveStarsCount = 8,
+            )
+            every { productReviewRepository.getProductReviewRating(productId) } returns rating
+
+            val result = productReviewService.getProductReviewRating(productId)
+
+            result.averageRating shouldBe rating.average
+            result.totalCount shouldBe rating.totalCount
+            result.ratingDistribution.oneStarCount shouldBe rating.oneStarCount
+            result.ratingDistribution.twoStarsCount shouldBe rating.twoStarsCount
+            result.ratingDistribution.threeStarsCount shouldBe rating.threeStarsCount
+            result.ratingDistribution.fourStarsCount shouldBe rating.fourStarsCount
+            result.ratingDistribution.fiveStarsCount shouldBe rating.fiveStarsCount
+        }
+        it("올바르지 않은 상품아이디로 별점 통계를 조회하면 기본 항목이 조회횐다.") {
+            val productId = 1L
+            every { productReviewRepository.getProductReviewRating(productId) } returns null
+
+            val result = productReviewService.getProductReviewRating(productId)
+
+            result.averageRating shouldBe 0
+            result.totalCount shouldBe 0
+            result.ratingDistribution.oneStarCount shouldBe 0
+            result.ratingDistribution.twoStarsCount shouldBe 0
+            result.ratingDistribution.threeStarsCount shouldBe 0
+            result.ratingDistribution.fourStarsCount shouldBe 0
+            result.ratingDistribution.fiveStarsCount shouldBe 0
         }
     }
 })

--- a/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ProductReviewControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/review/interfaces/ProductReviewControllerRestDocTest.kt
@@ -1,0 +1,102 @@
+package com.fastcampus.commerce.review.interfaces
+
+import com.fastcampus.commerce.restdoc.documentation
+import com.fastcampus.commerce.review.application.ProductReviewService
+import com.fastcampus.commerce.review.application.response.AdminReplyResponse
+import com.fastcampus.commerce.review.application.response.ProductReviewResponse
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.restassured.module.mockmvc.RestAssuredMockMvc
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.MockMvc
+import java.time.LocalDateTime
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@WebMvcTest(ProductReviewController::class)
+class ProductReviewControllerRestDocTest : DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var productReviewService: ProductReviewService
+
+    val tag = "Review"
+
+    init {
+        beforeSpec {
+            RestAssuredMockMvc.mockMvc(mockMvc)
+        }
+
+        describe("GET /product/{productId}/reviews - 상품 리뷰 목록 조회") {
+            val summary = "상품에 등록된 리뷰 목록 조회"
+            it("상품에 등록된 리뷰 목록을 조회할 수 있다.") {
+                val productId = 1L
+
+                val now = LocalDateTime.of(2025, 6, 1, 12, 0)
+                val productReviews = listOf(
+                    ProductReviewResponse(
+                        reviewId = 1L,
+                        rating = 5,
+                        content = "아주 만족해요",
+                        createdAt = now,
+                        adminReply = AdminReplyResponse(
+                            content = "감사합니다",
+                            createdAt = now,
+                        ),
+                    ),
+                )
+                val response = PageImpl(productReviews, PageRequest.of(1, 10), productReviews.size.toLong())
+                every {
+                    productReviewService.getProductReviews(productId, any())
+                } returns response
+
+                documentation(
+                    identifier = "상품_리뷰목록_조회_성공",
+                    tag = tag,
+                    summary = summary,
+                ) {
+                    requestLine(HttpMethod.GET, "/products/{productId}/reviews") {
+                        pathVariable("productId", "상품 아이디", productId)
+                    }
+
+                    queryParameters {
+                        optionalField("page", "페이지(기본 값: 1)", 1)
+                    }
+
+                    responseBody {
+                        field("data.content[0].reviewId", "리뷰 아이디", productReviews[0].reviewId.toInt())
+                        field("data.content[0].rating", "별점", productReviews[0].rating)
+                        field("data.content[0].content", "리뷰 내용", productReviews[0].content)
+                        field("data.content[0].createdAt", "리뷰 작성일", productReviews[0].createdAt.toString())
+                        optionalField(
+                            "data.content[0].adminReply.content",
+                            "관리자 답글 내용",
+                            productReviews[0].adminReply?.content,
+                        )
+                        optionalField(
+                            "data.content[0].adminReply.createdAt",
+                            "관리자 답글 작성일",
+                            productReviews[0].adminReply?.createdAt.toString(),
+                        )
+                        field("data.page", "현재 페이지 (기본값 1)", response.number)
+                        field("data.size", "페이지 사이즈(기본값 10)", response.size)
+                        field("data.totalPages", "전체 페이지 수", response.totalPages)
+                        field("data.totalElements", "총 수", response.totalElements.toInt())
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
- 상품 리뷰 관련 API 추가

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->
- 상품리뷰 목록
- 상품리뷰 별점 통계

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #47 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->