### PR TITLE
feat(cart) : 장바구니 상품 조회 기능 구현 (#18)

### DIFF
--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -243,13 +243,12 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: "#/components/schemas/cart-items-408437586"
+              $ref: "#/components/schemas/cart-items367995349"
             examples:
               장바구니_상품_수정_성공:
                 value: |-
                   {
                     "cartId" : 1,
-                    "userId" : 1,
                     "productId" : 1,
                     "quantity" : 100
                   }
@@ -270,6 +269,56 @@ paths:
                         "quantity" : 80,
                         "stockQuantity" : 80,
                         "requiresQuantityAdjustment" : true
+                      },
+                      "error" : null
+                    }
+  /carts:
+    get:
+      tags:
+      - Cart
+      summary: 장바구니에 담긴 상품 목록을 조회할 수 있다.
+      operationId: 장바구니_상품_목록_조회_성공
+      parameters:
+      - name: Authorization
+        in: header
+        description: Authorization
+        required: true
+        schema:
+          type: string
+        example: Bearer sample-token
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/carts-761185737"
+              examples:
+                장바구니_상품_목록_조회_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "totalPrice" : 80000,
+                        "deliveryPrice" : 0,
+                        "cartItems" : [ {
+                          "cartItemId" : 101,
+                          "productId" : 1,
+                          "productName" : "Product 1",
+                          "quantity" : 2,
+                          "price" : 10000,
+                          "stockQuantity" : 10,
+                          "thumbnail" : "thumbnail1.jpg",
+                          "isAvailable" : true
+                        }, {
+                          "cartItemId" : 102,
+                          "productId" : 2,
+                          "productName" : "Product 2",
+                          "quantity" : 3,
+                          "price" : 20000,
+                          "stockQuantity" : 5,
+                          "thumbnail" : "thumbnail2.jpg",
+                          "isAvailable" : true
+                        } ]
                       },
                       "error" : null
                     }
@@ -613,26 +662,6 @@ components:
         content:
           type: string
           description: 리뷰 내용
-    cart-items-408437586:
-      required:
-      - cartId
-      - productId
-      - quantity
-      - userId
-      type: object
-      properties:
-        quantity:
-          type: number
-          description: 수량
-        productId:
-          type: number
-          description: 상품 아이디
-        cartId:
-          type: number
-          description: 카트 아이디
-        userId:
-          type: number
-          description: 유저 아이디
     files-presigned-url-1375438577:
       required:
       - contentType
@@ -812,6 +841,61 @@ components:
         detailImage:
           type: string
           description: 상세 이미지
+    carts-761185737:
+      type: object
+      properties:
+        data:
+          required:
+          - cartItems
+          - deliveryPrice
+          - totalPrice
+          type: object
+          properties:
+            totalPrice:
+              type: number
+              description: 총 상품 금액 (배송비 제외)
+            deliveryPrice:
+              type: number
+              description: 배송비
+            cartItems:
+              type: array
+              description: 장바구니 상품 목록
+              items:
+                required:
+                - cartItemId
+                - isAvailable
+                - price
+                - productId
+                - productName
+                - quantity
+                - stockQuantity
+                - thumbnail
+                type: object
+                properties:
+                  isAvailable:
+                    type: boolean
+                    description: 구매 가능 여부
+                  thumbnail:
+                    type: string
+                    description: 상품 썸네일 이미지 URL
+                  quantity:
+                    type: number
+                    description: 수량
+                  productId:
+                    type: number
+                    description: 상품 ID
+                  price:
+                    type: number
+                    description: 상품 단가
+                  stockQuantity:
+                    type: number
+                    description: 재고 수량
+                  productName:
+                    type: string
+                    description: 상품명
+                  cartItemId:
+                    type: number
+                    description: 장바구니 아이템 ID
     cart-items151658045:
       type: object
       properties:
@@ -848,6 +932,22 @@ components:
               label:
                 type: string
                 description: 판매상태
+    cart-items367995349:
+      required:
+      - cartId
+      - productId
+      - quantity
+      type: object
+      properties:
+        quantity:
+          type: number
+          description: 수량
+        productId:
+          type: number
+          description: 상품 아이디
+        cartId:
+          type: number
+          description: 카트 아이디
     products-productId-reviews-352554938:
       type: object
       properties:

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -41,7 +41,7 @@ class CartItemService(
                 productId = product.id!!,
                 productName = product.name,
                 quantity = cartItem.quantity,
-                price = product.price.toLong(),
+                price = product.price,
                 stockQuantity = inventory.quantity,
                 thumbnail = product.thumbnail,
                 isAvailable = isAvailable

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -19,16 +19,16 @@ import org.springframework.transaction.annotation.Transactional
 class CartItemService(
     private val cartItemRepository: CartItemRepository,
     private val productReader: ProductReader,
-    private val deliveryPolicy: DeliveryPolicy
+    private val deliveryPolicy: DeliveryPolicy,
 ) {
-    fun getCarts(userId: Long) : CartRetrievesResponse{
+    fun getCarts(userId: Long): CartRetrievesResponse  {
         val cartItems = cartItemRepository.findAllByUserId(userId) ?: emptyList()
 
         if (cartItems.isEmpty()) {
             return CartRetrievesResponse(
                 totalPrice = 0,
                 deliveryPrice = 0,
-                cartItems = emptyList()
+                cartItems = emptyList(),
             )
         }
 
@@ -46,7 +46,7 @@ class CartItemService(
                 price = product.price,
                 stockQuantity = inventory.quantity,
                 thumbnail = product.thumbnail,
-                isAvailable = isAvailable
+                isAvailable = isAvailable,
             )
         }
 
@@ -60,10 +60,9 @@ class CartItemService(
         return CartRetrievesResponse(
             totalPrice = totalPrice,
             deliveryPrice = deliveryPrice,
-            cartItems = cartItemRetrieveList
+            cartItems = cartItemRetrieveList,
         )
     }
-
 
     @Transactional
     fun addToCart(userId: Long, productId: Long, quantity: Int): CartCreateResponse {

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -6,6 +6,7 @@ import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
 import com.fastcampus.commerce.cart.interfaces.CartCreateResponse
 import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
 import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
+import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.cart.interfaces.CartUpdateResponse
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 class CartItemService(
     private val cartItemRepository: CartItemRepository,
     private val productReader: ProductReader,
+    private val deliveryPolicy: DeliveryPolicy
 ) {
     fun getCarts(userId: Long) : CartRetrievesResponse{
         val cartItems = cartItemRepository.findAllByUserId(userId) ?: emptyList()
@@ -53,7 +55,7 @@ class CartItemService(
             .filter { it.isAvailable }
             .sumOf { it.price * it.quantity }
 
-        val deliveryPrice = if (totalPrice >= 30000) 0 else 3000
+        val deliveryPrice = deliveryPolicy.calculateDeliveryFee(totalPrice)
 
         return CartRetrievesResponse(
             totalPrice = totalPrice,

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -112,9 +112,9 @@ class CartItemService(
     }
 
     @Transactional
-    fun updateCartItem(request: CartUpdateRequest): CartUpdateResponse {
+    fun updateCartItem(userId: Long,request: CartUpdateRequest): CartUpdateResponse {
         var requireQuantityAdjustment = false
-        val cartItem = cartItemRepository.findByUserIdAndId(request.userId, request.cartId)
+        val cartItem = cartItemRepository.findByUserIdAndId(userId, request.cartId)
             ?: throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
 
         val inventory = productReader.getInventoryByProductId(cartItem.productId)
@@ -129,7 +129,7 @@ class CartItemService(
         cartItemRepository.save(cartItem)
 
         return CartUpdateResponse(
-            userId = request.userId,
+            userId = userId,
             productId = cartItem.productId,
             quantity = cartItem.quantity,
             stockQuantity = inventory.quantity,

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -52,7 +52,6 @@ class CartItemService(
         val totalPrice = cartItemRetrieveList
             .filter { it.isAvailable }
             .sumOf { it.price * it.quantity }
-            .toInt()
 
         val deliveryPrice = if (totalPrice >= 30000) 0 else 3000
 

--- a/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
@@ -10,5 +10,7 @@ interface CartItemRepository : JpaRepository<CartItem, Long> {
 
     fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
 
+    fun findAllByUserId(userId: Long): List<CartItem>?
+
     fun findByUserIdAndId(userId: Long, cartItemId: Long): CartItem?
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -17,7 +17,7 @@ class CartItemController(
     @GetMapping("/carts")
     fun getCarts(
         @RequestParam userId: Long,
-    ) : CartRetrievesResponse {
+    ): CartRetrievesResponse {
         return cartItemService.getCarts(userId)
     }
 

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -2,12 +2,9 @@ package com.fastcampus.commerce.cart.interfaces
 
 import com.fastcampus.commerce.cart.application.CartItemService
 import org.springframework.web.bind.annotation.GetMapping
-//import com.fastcampus.commerce.user.domain.entity.User
-//import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,26 +13,27 @@ class CartItemController(
 ) {
     @GetMapping("/carts")
     fun getCarts(
-//        @AuthenticationPrincipal user: User,
     ): CartRetrievesResponse {
-        return cartItemService.getCarts(1L)
+        val userId = 1L
+        return cartItemService.getCarts(userId)
     }
 
     @PostMapping("/cart/items")
     fun addToCart(
         @RequestBody request: CartCreateRequest,
-//        @AuthenticationPrincipal user: User
     ): CartCreateResponse {
-        val response = cartItemService.addToCart(1L, request.productId, request.quantity)
+        val userId = 1L
+        val response = cartItemService.addToCart(userId, request.productId, request.quantity)
         return response
     }
 
     @PatchMapping("/cart/items")
     fun updateCartItem(
-//        @AuthenticationPrincipal user: User,
         @RequestBody request: CartUpdateRequest,
-    ): CartUpdateResponse {
-        val cartResponse = cartItemService.updateCartItem(1L,request)
+    ): CartUpdateResponse
+    {
+        val userId = 1L
+        val cartResponse = cartItemService.updateCartItem(userId,request)
         return cartResponse
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.cart.interfaces
 
 import com.fastcampus.commerce.cart.application.CartItemService
+import org.springframework.web.bind.annotation.GetMapping
 import com.fastcampus.commerce.user.domain.entity.User
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping
@@ -13,6 +14,13 @@ import org.springframework.web.bind.annotation.RestController
 class CartItemController(
     private val cartItemService: CartItemService,
 ) {
+    @GetMapping("/carts")
+    fun getCarts(
+        @RequestParam userId: Long,
+    ) : CartRetrievesResponse {
+        return cartItemService.getCarts(userId)
+    }
+
     @PostMapping("/cart/items")
     fun addToCart(
         @RequestBody request: CartCreateRequest,

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -2,8 +2,8 @@ package com.fastcampus.commerce.cart.interfaces
 
 import com.fastcampus.commerce.cart.application.CartItemService
 import org.springframework.web.bind.annotation.GetMapping
-import com.fastcampus.commerce.user.domain.entity.User
-import org.springframework.security.core.annotation.AuthenticationPrincipal
+//import com.fastcampus.commerce.user.domain.entity.User
+//import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,25 +16,26 @@ class CartItemController(
 ) {
     @GetMapping("/carts")
     fun getCarts(
-        @RequestParam userId: Long,
+//        @AuthenticationPrincipal user: User,
     ): CartRetrievesResponse {
-        return cartItemService.getCarts(userId)
+        return cartItemService.getCarts(1L)
     }
 
     @PostMapping("/cart/items")
     fun addToCart(
         @RequestBody request: CartCreateRequest,
-        @AuthenticationPrincipal user: User
+//        @AuthenticationPrincipal user: User
     ): CartCreateResponse {
-        val response = cartItemService.addToCart(user.id!!, request.productId, request.quantity)
+        val response = cartItemService.addToCart(1L, request.productId, request.quantity)
         return response
     }
 
     @PatchMapping("/cart/items")
     fun updateCartItem(
+//        @AuthenticationPrincipal user: User,
         @RequestBody request: CartUpdateRequest,
     ): CartUpdateResponse {
-        val cartResponse = cartItemService.updateCartItem(request)
+        val cartResponse = cartItemService.updateCartItem(1L,request)
         return cartResponse
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -13,7 +13,6 @@ data class CartCreateResponse(
 
 data class CartUpdateRequest(
     val cartId: Long,
-    val userId: Long,
     val productId: Long,
     val quantity: Int,
 )

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -25,3 +25,20 @@ data class CartUpdateResponse(
     val stockQuantity: Int,
     val requiresQuantityAdjustment: Boolean,
 )
+
+data class CartRetrievesResponse(
+    val totalPrice: Int,
+    val deliveryPrice: Int,
+    val cartItems: List<CartItemRetrieve>
+)
+
+data class CartItemRetrieve(
+    val cartItemId: Long,
+    val productId: Long,
+    val productName: String,
+    val quantity: Int,
+    val price: Long,
+    val stockQuantity: Int,
+    val thumbnail: String,
+    val isAvailable: Boolean,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -29,7 +29,7 @@ data class CartUpdateResponse(
 data class CartRetrievesResponse(
     val totalPrice: Int,
     val deliveryPrice: Int,
-    val cartItems: List<CartItemRetrieve>
+    val cartItems: List<CartItemRetrieve>,
 )
 
 data class CartItemRetrieve(

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -37,7 +37,7 @@ data class CartItemRetrieve(
     val productId: Long,
     val productName: String,
     val quantity: Int,
-    val price: Long,
+    val price: Int,
     val stockQuantity: Int,
     val thumbnail: String,
     val isAvailable: Boolean,

--- a/src/main/kotlin/com/fastcampus/commerce/common/policy/DeliveryPolicy.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/policy/DeliveryPolicy.kt
@@ -1,0 +1,15 @@
+package com.fastcampus.commerce.common.policy
+
+import org.springframework.stereotype.Component
+
+@Component
+class DeliveryPolicy {
+
+    fun calculateDeliveryFee(totalPrice : Int) : Int{
+        return if(totalPrice >=30000) {
+            0
+        } else{
+            3000
+        }
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/common/policy/DeliveryPolicy.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/policy/DeliveryPolicy.kt
@@ -4,11 +4,10 @@ import org.springframework.stereotype.Component
 
 @Component
 class DeliveryPolicy {
-
-    fun calculateDeliveryFee(totalPrice : Int) : Int{
-        return if(totalPrice >=30000) {
+    fun calculateDeliveryFee(totalPrice: Int): Int  {
+        return if (totalPrice >= 30000) {
             0
-        } else{
+        } else {
             3000
         }
     }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -2,8 +2,6 @@ package com.fastcampus.commerce.cart.application
 
 import com.fastcampus.commerce.cart.domain.entity.CartItem
 import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
-import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
-import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
 import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.product.domain.entity.Inventory
@@ -201,12 +199,12 @@ class CartItemServiceTest {
     }
 
     @Test
-    fun `해당 유저의 상품 전체 조회가 가능해야 한다`(){
+    fun `해당 유저의 상품 전체 조회가 가능해야 한다`()  {
         // Given
         val userId = 1L
         val cartItems = listOf(
             CartItem(userId, 1L, 2),
-            CartItem(userId, 2L, 3)
+            CartItem(userId, 2L, 3),
         )
 
         // Set IDs for cart items
@@ -218,7 +216,7 @@ class CartItemServiceTest {
             name = "Product 1",
             price = 10000,
             thumbnail = "thumbnail1.jpg",
-            detailImage = "detail1.jpg"
+            detailImage = "detail1.jpg",
         )
         product1.id = 1L
         product1.status = SellingStatus.ON_SALE
@@ -227,7 +225,7 @@ class CartItemServiceTest {
             name = "Product 2",
             price = 20000,
             thumbnail = "thumbnail2.jpg",
-            detailImage = "detail2.jpg"
+            detailImage = "detail2.jpg",
         )
         product2.id = 2L
         product2.status = SellingStatus.ON_SALE
@@ -280,7 +278,7 @@ class CartItemServiceTest {
         // Then
         assertEquals(0, result.cartItems.size)
         assertEquals(0, result.totalPrice)
-        assertEquals(0, result.deliveryPrice)  // 빈 장바구니는 배송비 무료
+        assertEquals(0, result.deliveryPrice) // 빈 장바구니는 배송비 무료
     }
 
     @Test
@@ -288,8 +286,8 @@ class CartItemServiceTest {
         // Given
         val userId = 1L
         val cartItems = listOf(
-            CartItem(userId, 1L, 2),  // 10,000원 x 2 = 20,000원 (AVAILABLE)
-            CartItem(userId, 2L, 3)   // 5,000원 x 3 = 15,000원 (UNAVAILABLE)
+            CartItem(userId, 1L, 2), // 10,000원 x 2 = 20,000원 (AVAILABLE)
+            CartItem(userId, 2L, 3), // 5,000원 x 3 = 15,000원 (UNAVAILABLE)
         )
 
         // CartItem ID 설정
@@ -300,14 +298,14 @@ class CartItemServiceTest {
             name = "Product 1",
             price = 10000,
             thumbnail = "thumbnail1.jpg",
-            detailImage = "detail1.jpg"
+            detailImage = "detail1.jpg",
         )
 
         val product2 = Product(
             name = "Product 2",
             price = 20000,
             thumbnail = "thumbnail2.jpg",
-            detailImage = "detail2.jpg"
+            detailImage = "detail2.jpg",
         )
 
         product1.id = 1L
@@ -331,7 +329,7 @@ class CartItemServiceTest {
         val result = cartItemService.getCarts(userId)
 
         // Then
-        assertEquals(20000, result.totalPrice)  // UNAVAILABLE 상품 제외
-        assertEquals(3000, result.deliveryPrice)  // 30,000원 미만이므로 배송비 부과
+        assertEquals(20000, result.totalPrice) // UNAVAILABLE 상품 제외
+        assertEquals(3000, result.deliveryPrice) // 30,000원 미만이므로 배송비 부과
     }
 }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -139,14 +139,14 @@ class CartItemServiceTest {
         val inventory = Inventory(productId, inventoryQuantity)
         inventory.id = productId
 
-        val request = CartUpdateRequest(cartItemId, userId, productId, requestQuantity)
+        val request = CartUpdateRequest(cartItemId, productId, requestQuantity)
 
         `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
         `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
         `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
 
         // When
-        val result = cartItemService.updateCartItem(request)
+        val result = cartItemService.updateCartItem(userId,request)
 
         // Then
         verify(cartItemRepository).save(any(CartItem::class.java))
@@ -176,14 +176,14 @@ class CartItemServiceTest {
         val inventory = Inventory(productId, inventoryQuantity)
         inventory.id = productId
 
-        val request = CartUpdateRequest(cartItemId, userId, productId, requestQuantity)
+        val request = CartUpdateRequest(cartItemId, productId, requestQuantity)
 
         `when`(cartItemRepository.findByUserIdAndId(userId, cartItemId)).thenReturn(cartItem)
         `when`(productReader.getInventoryByProductId(productId)).thenReturn(inventory)
         `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
 
         // When
-        val result = cartItemService.updateCartItem(request)
+        val result = cartItemService.updateCartItem(userId,request)
 
         // Then
         verify(cartItemRepository).save(any(CartItem::class.java))

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -4,6 +4,7 @@ import com.fastcampus.commerce.cart.domain.entity.CartItem
 import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
 import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
 import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
+import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
@@ -24,12 +25,14 @@ class CartItemServiceTest {
     private lateinit var cartItemRepository: CartItemRepository
     private lateinit var productReader: ProductReader
     private lateinit var cartItemService: CartItemService
+    private lateinit var deliveryPolicy: DeliveryPolicy
 
     @BeforeEach
     fun setUp() {
         cartItemRepository = mock(CartItemRepository::class.java)
         productReader = mock(ProductReader::class.java)
-        cartItemService = CartItemService(cartItemRepository, productReader)
+        deliveryPolicy = DeliveryPolicy()
+        cartItemService = CartItemService(cartItemRepository, productReader, deliveryPolicy)
     }
 
     @Test

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -67,7 +67,6 @@ class CartItemControllerRestDocTest : DescribeSpec() {
 
                     requestHeaders {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
-                        header("X-User-Token", "사용자 ID", userId.toString())
                     }
 
                     requestBody {
@@ -131,7 +130,6 @@ class CartItemControllerRestDocTest : DescribeSpec() {
 
                     requestHeaders {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
-//                        header("X-User-Token", "user ID", userId.toString())
                     }
 
                     requestBody {

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -95,7 +95,6 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                 val request = CartUpdateRequest(
                     productId = productId,
                     quantity = 100,
-                    userId = userId,
                     cartId = cartId,
                 )
 
@@ -120,7 +119,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     requiresQuantityAdjustment = true,
                 )
 
-                every { cartItemService.updateCartItem(request) } returns response
+                every { cartItemService.updateCartItem(userId,request) } returns response
 
                 documentation(
                     identifier = "장바구니_상품_수정_성공",
@@ -132,11 +131,11 @@ class CartItemControllerRestDocTest : DescribeSpec() {
 
                     requestHeaders {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+//                        header("X-User-Token", "user ID", userId.toString())
                     }
 
                     requestBody {
                         field("cartId", "카트 아이디", request.cartId)
-                        field("userId", "유저 아이디", request.userId)
                         field("productId", "상품 아이디", request.productId)
                         field("quantity", "수량", request.quantity)
                     }
@@ -156,6 +155,37 @@ class CartItemControllerRestDocTest : DescribeSpec() {
         describe("GET /carts - 장바구니 상품 목록 조회"){
             val summary = "장바구니에 담긴 상품 목록을 조회할 수 있다."
             it("장바구니에 담긴 상품 목록을 조회할 수 있다."){
+                val cartItems = listOf(
+                    CartItemRetrieve(
+                        cartItemId = 101,
+                        productId = 1,
+                        productName = "Product 1",
+                        quantity = 2,
+                        price = 10000,
+                        stockQuantity = 10,
+                        thumbnail = "thumbnail1.jpg",
+                        isAvailable = true
+                    ),
+                    CartItemRetrieve(
+                        cartItemId = 102,
+                        productId = 2,
+                        productName = "Product 2",
+                        quantity = 3,
+                        price = 20000,
+                        stockQuantity = 5,
+                        thumbnail = "thumbnail2.jpg",
+                        isAvailable = true
+                    )
+                )
+
+                val cartResponse = CartRetrievesResponse(
+                    totalPrice = 80000,
+                    deliveryPrice = 0,
+                    cartItems = cartItems
+                )
+
+                every { cartItemService.getCarts(1L) } returns cartResponse
+
                 documentation(
                     identifier = "장바구니_상품_목록_조회_성공",
                     tag = tag,
@@ -168,11 +198,12 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
                     }
 
+
                     responseBody {
                         // 최상위 필드들
-                        field("totalPrice", "총 상품 금액 (배송비 제외)", 80000)
-                        field("deliveryPrice", "배송비", 0)
-                        field("cartItems", "장바구니 상품 목록", listOf(
+                        field("data.totalPrice", "총 상품 금액 (배송비 제외)", 80000)
+                        field("data.deliveryPrice", "배송비", 0)
+                        field("data.cartItems", "장바구니 상품 목록", listOf(
                             mapOf(
                                 "cartItemId" to 101,
                                 "productId" to 1,
@@ -196,14 +227,15 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         ))
 
                         // cartItems 배열 내부 필드들
-                        field("cartItems[].cartItemId", "장바구니 아이템 ID", 101)
-                        field("cartItems[].productId", "상품 ID", 1)
-                        field("cartItems[].productName", "상품명", "Product 1")
-                        field("cartItems[].quantity", "수량", 2)
-                        field("cartItems[].price", "상품 단가", 10000)
-                        field("cartItems[].stockQuantity", "재고 수량", 10)
-                        field("cartItems[].thumbnail", "상품 썸네일 이미지 URL", "thumbnail1.jpg")
-                        field("cartItems[].isAvailable", "구매 가능 여부", true)
+                        field("data.cartItems[0].cartItemId", "장바구니 아이템 ID", 101)
+                        field("data.cartItems[0].productId", "상품 ID", 1)
+                        field("data.cartItems[0].productName", "상품명", "Product 1")
+                        field("data.cartItems[0].quantity", "수량", 2)
+                        field("data.cartItems[0].price", "상품 단가", 10000)
+                        field("data.cartItems[0].stockQuantity", "재고 수량", 10)
+                        field("data.cartItems[0].thumbnail", "상품 썸네일 이미지 URL", "thumbnail1.jpg")
+                        field("data.cartItems[0].isAvailable", "구매 가능 여부", true)
+                        ignoredField("error")
                     }
                 }
             }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -63,11 +63,11 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     summary = summary,
                     privateResource = privateResource,
                 ) {
-                    requestLine(HttpMethod.POST, "/cart/items") {
-                    }
+                    requestLine(HttpMethod.POST, "/cart/items")
 
                     requestHeaders {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                        header("X-User-Token", "사용자 ID", userId.toString())
                     }
 
                     requestBody {
@@ -148,6 +148,62 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         field("data.stockQuantity", "재고 수량", response.stockQuantity)
                         field("data.requiresQuantityAdjustment", "수량 변경 여부", response.requiresQuantityAdjustment)
                         ignoredField("error")
+                    }
+                }
+            }
+        }
+
+        describe("GET /carts - 장바구니 상품 목록 조회"){
+            val summary = "장바구니에 담긴 상품 목록을 조회할 수 있다."
+            it("장바구니에 담긴 상품 목록을 조회할 수 있다."){
+                documentation(
+                    identifier = "장바구니_상품_목록_조회_성공",
+                    tag = tag,
+                    summary = summary,
+                    privateResource = privateResource,
+                ){
+                    requestLine(HttpMethod.GET, "/carts")
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    responseBody {
+                        // 최상위 필드들
+                        field("totalPrice", "총 상품 금액 (배송비 제외)", 80000)
+                        field("deliveryPrice", "배송비", 0)
+                        field("cartItems", "장바구니 상품 목록", listOf(
+                            mapOf(
+                                "cartItemId" to 101,
+                                "productId" to 1,
+                                "productName" to "Product 1",
+                                "quantity" to 2,
+                                "price" to 10000,
+                                "stockQuantity" to 10,
+                                "thumbnail" to "thumbnail1.jpg",
+                                "isAvailable" to true
+                            ),
+                            mapOf(
+                                "cartItemId" to 102,
+                                "productId" to 2,
+                                "productName" to "Product 2",
+                                "quantity" to 3,
+                                "price" to 20000,
+                                "stockQuantity" to 5,
+                                "thumbnail" to "thumbnail2.jpg",
+                                "isAvailable" to true
+                            )
+                        ))
+
+                        // cartItems 배열 내부 필드들
+                        field("cartItems[].cartItemId", "장바구니 아이템 ID", 101)
+                        field("cartItems[].productId", "상품 ID", 1)
+                        field("cartItems[].productName", "상품명", "Product 1")
+                        field("cartItems[].quantity", "수량", 2)
+                        field("cartItems[].price", "상품 단가", 10000)
+                        field("cartItems[].stockQuantity", "재고 수량", 10)
+                        field("cartItems[].thumbnail", "상품 썸네일 이미지 URL", "thumbnail1.jpg")
+                        field("cartItems[].isAvailable", "구매 가능 여부", true)
                     }
                 }
             }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

- 장바구니 상품 조회 기능 구현
---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

- GET /carts 엔드포인트 추가
- 단위 테스트 추가 (cartItemServiceTest)
- RestDocs 테스트 추가 (CartControllerRestDocsTest)
---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

- authenticalprincipal 부분을 전부 제외했습니다.
---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 단위 테스트 : `cartItemServiceTest`
- [ ] RestDocs 테스트 : `CartControllerRestDocsTest`

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->

#18 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->