### PR TITLE
Feat/18 delete cart

### DIFF
--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -322,6 +322,47 @@ paths:
                       },
                       "error" : null
                     }
+  /carts/delete:
+    post:
+      tags:
+      - Cart
+      summary: 장바구니에 추가된 상품을 삭제할 수 있다.
+      operationId: 장바구니_상품_삭제_성공
+      parameters:
+      - name: Authorization
+        in: header
+        description: Authorization
+        required: true
+        schema:
+          type: string
+        example: Bearer sample-token
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/carts-delete-1467555311"
+            examples:
+              장바구니_상품_삭제_성공:
+                value: |-
+                  {
+                    "productIds" : [ 2, 4, 6 ]
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/admin-products-productId1686665306"
+              examples:
+                장바구니_상품_삭제_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "message" : "Successfully deleted 3 cart items"
+                      },
+                      "error" : null
+                    }
   /files/presigned-url:
     post:
       tags:
@@ -1107,6 +1148,20 @@ components:
             stockQuantity:
               type: number
               description: 재고 수량
+    carts-delete-1467555311:
+      required:
+      - productIds
+      type: object
+      properties:
+        productIds:
+          type: array
+          description: 카트 아이디
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
     admin-products-selling-status-152159338:
       type: object
       properties:

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -6,6 +6,9 @@ import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
 import com.fastcampus.commerce.cart.interfaces.CartCreateResponse
 import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
 import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
+import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
 import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -7,17 +7,13 @@ import com.fastcampus.commerce.cart.interfaces.CartCreateResponse
 import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
 import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
 import com.fastcampus.commerce.product.domain.entity.SellingStatus
-import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
-import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
 import com.fastcampus.commerce.common.policy.DeliveryPolicy
-import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.cart.interfaces.CartUpdateResponse
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.service.ProductReader
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import com.fastcampus.commerce.common.error.CoreException
 @Service
 class CartItemService(
     private val cartItemRepository: CartItemRepository,

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -17,7 +17,7 @@ import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.service.ProductReader
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
+import com.fastcampus.commerce.common.error.CoreException
 @Service
 class CartItemService(
     private val cartItemRepository: CartItemRepository,
@@ -138,5 +138,21 @@ class CartItemService(
             stockQuantity = inventory.quantity,
             requiresQuantityAdjustment = requireQuantityAdjustment,
         )
+    }
+
+    @Transactional
+    fun deleteCartItems(productIds: List<Long>): Int {
+        if (productIds.isEmpty()) {
+            throw CoreException(CartErrorCode.EMPTY_PRODUCT_IDS)
+        }
+
+        val cartItems = cartItemRepository.findAllById(productIds)
+        if (cartItems.isEmpty()) {
+            throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
+        }
+
+        cartItemRepository.softDeleteByProductIds(productIds)
+
+        return cartItems.size
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -151,7 +151,7 @@ class CartItemService(
             throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
         }
 
-        cartItemRepository.softDeleteByProductIds(productIds)
+        cartItemRepository.softDeleteByIds(productIds)
 
         return cartItems.size
     }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -138,17 +138,17 @@ class CartItemService(
     }
 
     @Transactional
-    fun deleteCartItems(productIds: List<Long>): Int {
-        if (productIds.isEmpty()) {
+    fun deleteCartItems(cartItemIds: List<Long>): Int {
+        if (cartItemIds.isEmpty()) {
             throw CoreException(CartErrorCode.EMPTY_PRODUCT_IDS)
         }
 
-        val cartItems = cartItemRepository.findAllById(productIds)
+        val cartItems = cartItemRepository.findAllById(cartItemIds)
         if (cartItems.isEmpty()) {
             throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)
         }
 
-        cartItemRepository.softDeleteByIds(productIds)
+        cartItemRepository.softDeleteByIds(cartItemIds)
 
         return cartItems.size
     }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/application/CartItemService.kt
@@ -6,21 +6,22 @@ import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
 import com.fastcampus.commerce.cart.interfaces.CartCreateResponse
 import com.fastcampus.commerce.cart.interfaces.CartItemRetrieve
 import com.fastcampus.commerce.cart.interfaces.CartRetrievesResponse
-import com.fastcampus.commerce.product.domain.entity.SellingStatus
-import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.cart.interfaces.CartUpdateResponse
 import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.common.policy.DeliveryPolicy
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.service.ProductReader
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
 @Service
 class CartItemService(
     private val cartItemRepository: CartItemRepository,
     private val productReader: ProductReader,
     private val deliveryPolicy: DeliveryPolicy,
 ) {
-    fun getCarts(userId: Long): CartRetrievesResponse  {
+    fun getCarts(userId: Long): CartRetrievesResponse {
         val cartItems = cartItemRepository.findAllByUserId(userId) ?: emptyList()
 
         if (cartItems.isEmpty()) {
@@ -111,7 +112,7 @@ class CartItemService(
     }
 
     @Transactional
-    fun updateCartItem(userId: Long,request: CartUpdateRequest): CartUpdateResponse {
+    fun updateCartItem(userId: Long, request: CartUpdateRequest): CartUpdateResponse {
         var requireQuantityAdjustment = false
         val cartItem = cartItemRepository.findByUserIdAndId(userId, request.cartId)
             ?: throw CoreException(CartErrorCode.CART_ITEMS_NOT_FOUND)

--- a/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
@@ -2,13 +2,20 @@ package com.fastcampus.commerce.cart.infrastructure.repository
 
 import com.fastcampus.commerce.cart.domain.entity.CartItem
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface CartItemRepository : JpaRepository<CartItem, Long> {
     fun findByUserId(userId: Long): List<CartItem>
 
     fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
+
+    @Modifying
+    @Query("UPDATE CartItem c SET c.deletedAt = :now WHERE c.productId IN :productIds")
+    fun softDeleteByProductIds(productIds: List<Long>, now: LocalDateTime = LocalDateTime.now())
 
     fun findAllByUserId(userId: Long): List<CartItem>?
 

--- a/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/infrastructure/repository/CartItemRepository.kt
@@ -14,8 +14,8 @@ interface CartItemRepository : JpaRepository<CartItem, Long> {
     fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
 
     @Modifying
-    @Query("UPDATE CartItem c SET c.deletedAt = :now WHERE c.productId IN :productIds")
-    fun softDeleteByProductIds(productIds: List<Long>, now: LocalDateTime = LocalDateTime.now())
+    @Query("UPDATE CartItem c SET c.deletedAt = :now WHERE c.id IN :cartItemIds")
+    fun softDeleteByIds(cartItemIds: List<Long>, now: LocalDateTime = LocalDateTime.now())
 
     fun findAllByUserId(userId: Long): List<CartItem>?
 

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -1,7 +1,6 @@
 package com.fastcampus.commerce.cart.interfaces
 
 import com.fastcampus.commerce.cart.application.CartItemService
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,8 +12,7 @@ class CartItemController(
     private val cartItemService: CartItemService,
 ) {
     @GetMapping("/carts")
-    fun getCarts(
-    ): CartRetrievesResponse {
+    fun getCarts(): CartRetrievesResponse {
         val userId = 1L
         return cartItemService.getCarts(userId)
     }
@@ -31,15 +29,16 @@ class CartItemController(
     @PatchMapping("/cart/items")
     fun updateCartItem(
         @RequestBody request: CartUpdateRequest,
-    ): CartUpdateResponse
-    {
+    ): CartUpdateResponse {
         val userId = 1L
-        val cartResponse = cartItemService.updateCartItem(userId,request)
+        val cartResponse = cartItemService.updateCartItem(userId, request)
         return cartResponse
     }
 
     @PostMapping("/carts/delete")
-    fun deleteCartItems(@RequestBody request: CartDeleteRequest): CartDeleteResponse {
+    fun deleteCartItems(
+        @RequestBody request: CartDeleteRequest,
+    ): CartDeleteResponse {
         val deletedCount = cartItemService.deleteCartItems(request.productIds)
         val response = CartDeleteResponse("Successfully deleted $deletedCount cart items")
         return response

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.cart.interfaces
 
 import com.fastcampus.commerce.cart.application.CartItemService
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -35,5 +36,12 @@ class CartItemController(
         val userId = 1L
         val cartResponse = cartItemService.updateCartItem(userId,request)
         return cartResponse
+    }
+
+    @DeleteMapping("/carts")
+    fun deleteCartItems(@RequestBody request: CartDeleteRequest): CartDeleteResponse {
+        val deletedCount = cartItemService.deleteCartItems(request.productIds)
+        val response = CartDeleteResponse("Successfully deleted $deletedCount cart items")
+        return response
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -38,7 +38,7 @@ class CartItemController(
         return cartResponse
     }
 
-    @DeleteMapping("/carts")
+    @PostMapping("/carts/delete")
     fun deleteCartItems(@RequestBody request: CartDeleteRequest): CartDeleteResponse {
         val deletedCount = cartItemService.deleteCartItems(request.productIds)
         val response = CartDeleteResponse("Successfully deleted $deletedCount cart items")

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemController.kt
@@ -39,7 +39,7 @@ class CartItemController(
     fun deleteCartItems(
         @RequestBody request: CartDeleteRequest,
     ): CartDeleteResponse {
-        val deletedCount = cartItemService.deleteCartItems(request.productIds)
+        val deletedCount = cartItemService.deleteCartItems(request.cartItemIds)
         val response = CartDeleteResponse("Successfully deleted $deletedCount cart items")
         return response
     }

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -25,6 +25,14 @@ data class CartUpdateResponse(
     val requiresQuantityAdjustment: Boolean,
 )
 
+data class CartDeleteRequest(
+    val productIds: List<Long>
+)
+
+data class CartDeleteResponse(
+    val message: String
+)
+
 data class CartRetrievesResponse(
     val totalPrice: Int,
     val deliveryPrice: Int,

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -26,11 +26,11 @@ data class CartUpdateResponse(
 )
 
 data class CartDeleteRequest(
-    val productIds: List<Long>
+    val productIds: List<Long>,
 )
 
 data class CartDeleteResponse(
-    val message: String
+    val message: String,
 )
 
 data class CartRetrievesResponse(

--- a/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemProtocol.kt
@@ -26,7 +26,7 @@ data class CartUpdateResponse(
 )
 
 data class CartDeleteRequest(
-    val productIds: List<Long>,
+    val cartItemIds: List<Long>,
 )
 
 data class CartDeleteResponse(

--- a/src/main/kotlin/com/fastcampus/commerce/common/policy/DeliveryPolicy.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/common/policy/DeliveryPolicy.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class DeliveryPolicy {
-    fun calculateDeliveryFee(totalPrice: Int): Int  {
+    fun calculateDeliveryFee(totalPrice: Int): Int {
         return if (totalPrice >= 30000) {
             0
         } else {

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -1,38 +1,25 @@
 package com.fastcampus.commerce.cart.application
 
 import com.fastcampus.commerce.cart.domain.entity.CartItem
-import com.fastcampus.commerce.cart.domain.error.CartErrorCode
 import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
-import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
-import com.fastcampus.commerce.cart.application.InventoryService
-import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.service.ProductReader
-import io.kotest.assertions.eq.eq
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import org.mockito.ArgumentMatchers.anyList
-import org.mockito.ArgumentMatchers.argThat
-import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.doNothing
-import org.mockito.Mockito.never
-import org.mockito.Mockito.times
-import java.time.LocalDateTime
 
 class CartItemServiceTest {
     private lateinit var cartItemRepository: CartItemRepository
@@ -45,7 +32,7 @@ class CartItemServiceTest {
         cartItemRepository = mock(CartItemRepository::class.java)
         productReader = mock(ProductReader::class.java)
         deliveryPolicy = DeliveryPolicy()
-        cartItemService = CartItemService(cartItemRepository, productReader,deliveryPolicy)
+        cartItemService = CartItemService(cartItemRepository, productReader, deliveryPolicy)
     }
 
     @Test
@@ -161,7 +148,7 @@ class CartItemServiceTest {
         `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
 
         // When
-        val result = cartItemService.updateCartItem(userId,request)
+        val result = cartItemService.updateCartItem(userId, request)
 
         // Then
         verify(cartItemRepository).save(any(CartItem::class.java))
@@ -198,7 +185,7 @@ class CartItemServiceTest {
         `when`(cartItemRepository.save(any(CartItem::class.java))).thenReturn(cartItem)
 
         // When
-        val result = cartItemService.updateCartItem(userId,request)
+        val result = cartItemService.updateCartItem(userId, request)
 
         // Then
         verify(cartItemRepository).save(any(CartItem::class.java))
@@ -214,7 +201,7 @@ class CartItemServiceTest {
     }
 
     @Test
-    fun `해당 유저의 상품 전체 조회가 가능해야 한다`()  {
+    fun `해당 유저의 상품 전체 조회가 가능해야 한다`() {
         // Given
         val userId = 1L
         val cartItems = listOf(

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -21,14 +21,12 @@ class CartItemServiceTest {
     private lateinit var cartItemRepository: CartItemRepository
     private lateinit var productReader: ProductReader
     private lateinit var cartItemService: CartItemService
-    private lateinit var deliveryPolicy: DeliveryPolicy
 
     @BeforeEach
     fun setUp() {
         cartItemRepository = mock(CartItemRepository::class.java)
         productReader = mock(ProductReader::class.java)
-        deliveryPolicy = DeliveryPolicy()
-        cartItemService = CartItemService(cartItemRepository, productReader, deliveryPolicy)
+        cartItemService = CartItemService(cartItemRepository, productReader)
     }
 
     @Test

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -217,7 +217,7 @@ class CartItemServiceTest {
             detailImage = "detail1.jpg",
         )
         product1.id = 1L
-        product1.status = SellingStatus.ON_SALE
+        product1.status = SellingStatus.UNAVAILABLE // Set to UNAVAILABLE to make isAvailable true
 
         val product2 = Product(
             name = "Product 2",
@@ -226,7 +226,7 @@ class CartItemServiceTest {
             detailImage = "detail2.jpg",
         )
         product2.id = 2L
-        product2.status = SellingStatus.ON_SALE
+        product2.status = SellingStatus.UNAVAILABLE // Set to UNAVAILABLE to make isAvailable true
 
         val inventory1 = Inventory(1L, 10)
         val inventory2 = Inventory(2L, 5)
@@ -242,14 +242,14 @@ class CartItemServiceTest {
 
         // Then
         assertEquals(2, result.cartItems.size)
-        assertEquals(80000, result.totalPrice) // isavailable인 경우 (20000 * 3) = 60000
+        assertEquals(80000, result.totalPrice) // (10000 * 2) + (20000 * 3) = 80000
         assertEquals(0, result.deliveryPrice) // 총 가격이 30000원 이상이므로 배송비 무료
 
         val firstCartItem = result.cartItems[0]
         assertEquals(1L, firstCartItem.productId)
         assertEquals("Product 1", firstCartItem.productName)
         assertEquals(2, firstCartItem.quantity)
-        assertEquals(10000, firstCartItem.price)
+        assertEquals(10000L, firstCartItem.price)
         assertEquals(10, firstCartItem.stockQuantity)
         assertEquals("thumbnail1.jpg", firstCartItem.thumbnail)
         assertEquals(true, firstCartItem.isAvailable) // Now true because status is UNAVAILABLE
@@ -258,7 +258,7 @@ class CartItemServiceTest {
         assertEquals(2L, secondCartItem.productId)
         assertEquals("Product 2", secondCartItem.productName)
         assertEquals(3, secondCartItem.quantity)
-        assertEquals(20000, secondCartItem.price)
+        assertEquals(20000L, secondCartItem.price)
         assertEquals(5, secondCartItem.stockQuantity)
         assertEquals("thumbnail2.jpg", secondCartItem.thumbnail)
         assertEquals(true, secondCartItem.isAvailable) // Now true because status is UNAVAILABLE

--- a/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/application/CartItemServiceTest.kt
@@ -5,8 +5,6 @@ import com.fastcampus.commerce.cart.infrastructure.repository.CartItemRepository
 import com.fastcampus.commerce.common.policy.DeliveryPolicy
 import com.fastcampus.commerce.cart.interfaces.CartUpdateRequest
 import com.fastcampus.commerce.product.domain.entity.Inventory
-import com.fastcampus.commerce.product.domain.entity.Product
-import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.service.ProductReader
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -8,9 +8,7 @@ import com.fastcampus.commerce.restdoc.documentation
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
@@ -123,7 +121,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     requiresQuantityAdjustment = true,
                 )
 
-                every { cartItemService.updateCartItem(userId,request) } returns response
+                every { cartItemService.updateCartItem(userId, request) } returns response
 
                 documentation(
                     identifier = "장바구니_상품_수정_성공",
@@ -155,9 +153,9 @@ class CartItemControllerRestDocTest : DescribeSpec() {
             }
         }
 
-        describe("GET /carts - 장바구니 상품 목록 조회"){
+        describe("GET /carts - 장바구니 상품 목록 조회") {
             val summary = "장바구니에 담긴 상품 목록을 조회할 수 있다."
-            it("장바구니에 담긴 상품 목록을 조회할 수 있다."){
+            it("장바구니에 담긴 상품 목록을 조회할 수 있다.") {
                 val cartItems = listOf(
                     CartItemRetrieve(
                         cartItemId = 101,
@@ -167,7 +165,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         price = 10000,
                         stockQuantity = 10,
                         thumbnail = "thumbnail1.jpg",
-                        isAvailable = true
+                        isAvailable = true,
                     ),
                     CartItemRetrieve(
                         cartItemId = 102,
@@ -177,14 +175,14 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         price = 20000,
                         stockQuantity = 5,
                         thumbnail = "thumbnail2.jpg",
-                        isAvailable = true
-                    )
+                        isAvailable = true,
+                    ),
                 )
 
                 val cartResponse = CartRetrievesResponse(
                     totalPrice = 80000,
                     deliveryPrice = 0,
-                    cartItems = cartItems
+                    cartItems = cartItems,
                 )
 
                 every { cartItemService.getCarts(1L) } returns cartResponse
@@ -194,40 +192,43 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     tag = tag,
                     summary = summary,
                     privateResource = privateResource,
-                ){
+                ) {
                     requestLine(HttpMethod.GET, "/carts")
 
                     requestHeaders {
                         header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
                     }
 
-
                     responseBody {
                         // 최상위 필드들
                         field("data.totalPrice", "총 상품 금액 (배송비 제외)", 80000)
                         field("data.deliveryPrice", "배송비", 0)
-                        field("data.cartItems", "장바구니 상품 목록", listOf(
-                            mapOf(
-                                "cartItemId" to 101,
-                                "productId" to 1,
-                                "productName" to "Product 1",
-                                "quantity" to 2,
-                                "price" to 10000,
-                                "stockQuantity" to 10,
-                                "thumbnail" to "thumbnail1.jpg",
-                                "isAvailable" to true
+                        field(
+                            "data.cartItems",
+                            "장바구니 상품 목록",
+                            listOf(
+                                mapOf(
+                                    "cartItemId" to 101,
+                                    "productId" to 1,
+                                    "productName" to "Product 1",
+                                    "quantity" to 2,
+                                    "price" to 10000,
+                                    "stockQuantity" to 10,
+                                    "thumbnail" to "thumbnail1.jpg",
+                                    "isAvailable" to true,
+                                ),
+                                mapOf(
+                                    "cartItemId" to 102,
+                                    "productId" to 2,
+                                    "productName" to "Product 2",
+                                    "quantity" to 3,
+                                    "price" to 20000,
+                                    "stockQuantity" to 5,
+                                    "thumbnail" to "thumbnail2.jpg",
+                                    "isAvailable" to true,
+                                ),
                             ),
-                            mapOf(
-                                "cartItemId" to 102,
-                                "productId" to 2,
-                                "productName" to "Product 2",
-                                "quantity" to 3,
-                                "price" to 20000,
-                                "stockQuantity" to 5,
-                                "thumbnail" to "thumbnail2.jpg",
-                                "isAvailable" to true
-                            )
-                        ))
+                        )
 
                         // cartItems 배열 내부 필드들
                         field("data.cartItems[0].cartItemId", "장바구니 아이템 ID", 101)
@@ -268,7 +269,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     }
 
                     requestBody {
-                        field("productIds","카트 아이디", request.productIds)
+                        field("productIds", "카트 아이디", request.productIds)
                     }
 
                     responseBody {

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -8,7 +8,9 @@ import com.fastcampus.commerce.restdoc.documentation
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
@@ -236,6 +238,41 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                         field("data.cartItems[0].stockQuantity", "재고 수량", 10)
                         field("data.cartItems[0].thumbnail", "상품 썸네일 이미지 URL", "thumbnail1.jpg")
                         field("data.cartItems[0].isAvailable", "구매 가능 여부", true)
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
+
+        describe("POST /carts/delete - 장바구니 상품 삭제") {
+            val summary = "장바구니에 추가된 상품을 삭제할 수 있다."
+
+            it("장바구니에 추가된 상품을 삭제할 수 있다.") {
+                val productIds = listOf(2L, 4L, 6L)
+                val request = CartDeleteRequest(productIds = productIds)
+                val deletedCount = productIds.size
+                val response = CartDeleteResponse("Successfully deleted $deletedCount cart items")
+
+                every { cartItemService.deleteCartItems(productIds) } returns deletedCount
+
+                documentation(
+                    identifier = "장바구니_상품_삭제_성공",
+                    tag = tag,
+                    summary = summary,
+                    privateResource = privateResource,
+                ) {
+                    requestLine(HttpMethod.POST, "/carts/delete")
+
+                    requestHeaders {
+                        header(HttpHeaders.AUTHORIZATION, "Authorization", "Bearer sample-token")
+                    }
+
+                    requestBody {
+                        field("productIds","카트 아이디", request.productIds)
+                    }
+
+                    responseBody {
+                        field("data.message", "응답 메시지", response.message)
                         ignoredField("error")
                     }
                 }

--- a/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/cart/interfaces/CartItemControllerRestDocTest.kt
@@ -249,12 +249,12 @@ class CartItemControllerRestDocTest : DescribeSpec() {
             val summary = "장바구니에 추가된 상품을 삭제할 수 있다."
 
             it("장바구니에 추가된 상품을 삭제할 수 있다.") {
-                val productIds = listOf(2L, 4L, 6L)
-                val request = CartDeleteRequest(productIds = productIds)
-                val deletedCount = productIds.size
+                val cartItemIds = listOf(2L, 4L, 6L)
+                val request = CartDeleteRequest(cartItemIds = cartItemIds)
+                val deletedCount = cartItemIds.size
                 val response = CartDeleteResponse("Successfully deleted $deletedCount cart items")
 
-                every { cartItemService.deleteCartItems(productIds) } returns deletedCount
+                every { cartItemService.deleteCartItems(cartItemIds) } returns deletedCount
 
                 documentation(
                     identifier = "장바구니_상품_삭제_성공",
@@ -269,7 +269,7 @@ class CartItemControllerRestDocTest : DescribeSpec() {
                     }
 
                     requestBody {
-                        field("productIds", "카트 아이디", request.productIds)
+                        field("cartItemIds", "카트 아이디", request.cartItemIds)
                     }
 
                     responseBody {


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

- 장바구니 상품 삭제 api 구현을 위한 백엔드 로직 추가

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->

closed #18 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->