### PR TITLE
[feat] 상품 카테고리 목록 조회 API 추가

### DIFF
--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -38,10 +38,16 @@ paths:
               $ref: "#/components/schemas/admin-products-247955186"
             examples:
               상품_등록_성공:
-                value: "{\r\n  \"name\" : \"콜드브루\",\r\n  \"price\" : 3500,\r\n  \"\
-                  quantity\" : 100,\r\n  \"thumbnail\" : \"https://test.com/thumbnail.png\"\
-                  ,\r\n  \"detailImage\" : \"https://test.com/detailImage.png\",\r\
-                  \n  \"intensityId\" : 1,\r\n  \"cupSizeId\" : 10\r\n}"
+                value: |-
+                  {
+                    "name" : "콜드브루",
+                    "price" : 3500,
+                    "quantity" : 100,
+                    "thumbnail" : "https://test.com/thumbnail.png",
+                    "detailImage" : "https://test.com/detailImage.png",
+                    "intensityId" : 1,
+                    "cupSizeId" : 10
+                  }
       responses:
         "200":
           description: "200"
@@ -51,8 +57,13 @@ paths:
                 $ref: "#/components/schemas/admin-products9820101"
               examples:
                 상품_등록_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"productId\" : 10\r\n  },\r\n\
-                    \  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "productId" : 10
+                      },
+                      "error" : null
+                    }
   /admin/products/selling-status:
     get:
       tags:
@@ -76,8 +87,14 @@ paths:
                 $ref: "#/components/schemas/admin-products-selling-status-152159338"
               examples:
                 상품_판매상태_조회_성공:
-                  value: "{\r\n  \"data\" : [ {\r\n    \"code\" : \"ON_SALE\",\r\n\
-                    \    \"label\" : \"판매중\"\r\n  } ],\r\n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : [ {
+                        "code" : "ON_SALE",
+                        "label" : "판매중"
+                      } ],
+                      "error" : null
+                    }
   /admin/products/{productId}:
     put:
       tags:
@@ -105,11 +122,17 @@ paths:
               $ref: "#/components/schemas/admin-products-productId-1789436874"
             examples:
               상품_수정_성공:
-                value: "{\r\n  \"name\" : \"콜드브루\",\r\n  \"price\" : 3500,\r\n  \"\
-                  quantity\" : 100,\r\n  \"thumbnail\" : \"https://test.com/thumbnail.png\"\
-                  ,\r\n  \"detailImage\" : \"https://test.com/detailImage.png\",\r\
-                  \n  \"intensityId\" : 1,\r\n  \"cupSizeId\" : 10,\r\n  \"status\"\
-                  \ : \"UNAVAILABLE\"\r\n}"
+                value: |-
+                  {
+                    "name" : "콜드브루",
+                    "price" : 3500,
+                    "quantity" : 100,
+                    "thumbnail" : "https://test.com/thumbnail.png",
+                    "detailImage" : "https://test.com/detailImage.png",
+                    "intensityId" : 1,
+                    "cupSizeId" : 10,
+                    "status" : "UNAVAILABLE"
+                  }
       responses:
         "200":
           description: "200"
@@ -119,8 +142,13 @@ paths:
                 $ref: "#/components/schemas/admin-products-productId-1712578160"
               examples:
                 상품_수정_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"productId\" : 10\r\n  },\r\n\
-                    \  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "productId" : 10
+                      },
+                      "error" : null
+                    }
     delete:
       tags:
       - Admin-Product
@@ -146,11 +174,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/carts-delete1686665306"
+                $ref: "#/components/schemas/admin-products-productId1686665306"
               examples:
                 상품_삭제_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
-                    \n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "message" : "OK"
+                      },
+                      "error" : null
+                    }
   /cart/items:
     post:
       tags:
@@ -172,7 +205,11 @@ paths:
               $ref: "#/components/schemas/cart-items1349440338"
             examples:
               장바구니에_상품_추가_성공:
-                value: "{\r\n  \"productId\" : 1,\r\n  \"quantity\" : 100\r\n}"
+                value: |-
+                  {
+                    "productId" : 1,
+                    "quantity" : 100
+                  }
       responses:
         "200":
           description: "200"
@@ -182,9 +219,15 @@ paths:
                 $ref: "#/components/schemas/cart-items151658045"
               examples:
                 장바구니에_상품_추가_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"quantity\" : 80,\r\n    \"\
-                    stockQuantity\" : 80,\r\n    \"requiresQuantityAdjustment\" :\
-                    \ true\r\n  },\r\n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "quantity" : 80,
+                        "stockQuantity" : 80,
+                        "requiresQuantityAdjustment" : true
+                      },
+                      "error" : null
+                    }
     patch:
       tags:
       - Cart
@@ -205,8 +248,12 @@ paths:
               $ref: "#/components/schemas/cart-items367995349"
             examples:
               장바구니_상품_수정_성공:
-                value: "{\r\n  \"cartId\" : 1,\r\n  \"productId\" : 1,\r\n  \"quantity\"\
-                  \ : 100\r\n}"
+                value: |-
+                  {
+                    "cartId" : 1,
+                    "productId" : 1,
+                    "quantity" : 100
+                  }
       responses:
         "200":
           description: "200"
@@ -216,10 +263,17 @@ paths:
                 $ref: "#/components/schemas/cart-items838557620"
               examples:
                 장바구니_상품_수정_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"userId\" : 1,\r\n    \"productId\"\
-                    \ : 1,\r\n    \"quantity\" : 80,\r\n    \"stockQuantity\" : 80,\r\
-                    \n    \"requiresQuantityAdjustment\" : true\r\n  },\r\n  \"error\"\
-                    \ : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "userId" : 1,
+                        "productId" : 1,
+                        "quantity" : 80,
+                        "stockQuantity" : 80,
+                        "requiresQuantityAdjustment" : true
+                      },
+                      "error" : null
+                    }
   /carts:
     get:
       tags:
@@ -243,18 +297,33 @@ paths:
                 $ref: "#/components/schemas/carts-761185737"
               examples:
                 장바구니_상품_목록_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"totalPrice\" : 80000,\r\n \
-                    \   \"deliveryPrice\" : 0,\r\n    \"cartItems\" : [ {\r\n    \
-                    \  \"cartItemId\" : 101,\r\n      \"productId\" : 1,\r\n     \
-                    \ \"productName\" : \"Product 1\",\r\n      \"quantity\" : 2,\r\
-                    \n      \"price\" : 10000,\r\n      \"stockQuantity\" : 10,\r\n\
-                    \      \"thumbnail\" : \"thumbnail1.jpg\",\r\n      \"isAvailable\"\
-                    \ : true\r\n    }, {\r\n      \"cartItemId\" : 102,\r\n      \"\
-                    productId\" : 2,\r\n      \"productName\" : \"Product 2\",\r\n\
-                    \      \"quantity\" : 3,\r\n      \"price\" : 20000,\r\n     \
-                    \ \"stockQuantity\" : 5,\r\n      \"thumbnail\" : \"thumbnail2.jpg\"\
-                    ,\r\n      \"isAvailable\" : true\r\n    } ]\r\n  },\r\n  \"error\"\
-                    \ : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "totalPrice" : 80000,
+                        "deliveryPrice" : 0,
+                        "cartItems" : [ {
+                          "cartItemId" : 101,
+                          "productId" : 1,
+                          "productName" : "Product 1",
+                          "quantity" : 2,
+                          "price" : 10000,
+                          "stockQuantity" : 10,
+                          "thumbnail" : "thumbnail1.jpg",
+                          "isAvailable" : true
+                        }, {
+                          "cartItemId" : 102,
+                          "productId" : 2,
+                          "productName" : "Product 2",
+                          "quantity" : 3,
+                          "price" : 20000,
+                          "stockQuantity" : 5,
+                          "thumbnail" : "thumbnail2.jpg",
+                          "isAvailable" : true
+                        } ]
+                      },
+                      "error" : null
+                    }
   /carts/delete:
     post:
       tags:
@@ -276,18 +345,26 @@ paths:
               $ref: "#/components/schemas/carts-delete1623445193"
             examples:
               장바구니_상품_삭제_성공:
-                value: "{\r\n  \"cartItemIds\" : [ 2, 4, 6 ]\r\n}"
+                value: |-
+                  {
+                    "cartItemIds" : [ 2, 4, 6 ]
+                  }
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/carts-delete1686665306"
+                $ref: "#/components/schemas/admin-products-productId1686665306"
               examples:
                 장바구니_상품_삭제_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"Successfully\
-                    \ deleted 3 cart items\"\r\n  },\r\n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "message" : "Successfully deleted 3 cart items"
+                      },
+                      "error" : null
+                    }
   /files/presigned-url:
     post:
       tags:
@@ -309,10 +386,15 @@ paths:
               $ref: "#/components/schemas/files-presigned-url-1375438577"
             examples:
               PresignedURL_발급_성공:
-                value: "{\r\n  \"fileName\" : \"사진입니다.jpg\",\r\n  \"contentType\"\
-                  \ : \"image/jpeg\",\r\n  \"fileSize\" : 1048576,\r\n  \"domainType\"\
-                  \ : \"PRODUCT\",\r\n  \"domainContext\" : \"thumbnail\",\r\n  \"\
-                  contextId\" : \"6d851850-3b6f-4230-97fe-1a55b44fc862\"\r\n}"
+                value: |-
+                  {
+                    "fileName" : "사진입니다.jpg",
+                    "contentType" : "image/jpeg",
+                    "fileSize" : 1048576,
+                    "domainType" : "PRODUCT",
+                    "domainContext" : "thumbnail",
+                    "contextId" : "6d851850-3b6f-4230-97fe-1a55b44fc862"
+                  }
       responses:
         "200":
           description: "200"
@@ -322,10 +404,15 @@ paths:
                 $ref: "#/components/schemas/files-presigned-url-2064193514"
               examples:
                 PresignedURL_발급_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"uploadUrl\" : \"https://test-801base-bucket.com/product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg\"\
-                    ,\r\n    \"key\" : \"product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg\"\
-                    ,\r\n    \"contextId\" : \"6d851850-3b6f-4230-97fe-1a55b44fc862\"\
-                    \r\n  },\r\n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "uploadUrl" : "https://test-801base-bucket.com/product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg",
+                        "key" : "product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg",
+                        "contextId" : "6d851850-3b6f-4230-97fe-1a55b44fc862"
+                      },
+                      "error" : null
+                    }
   /products:
     get:
       tags:
@@ -335,8 +422,8 @@ paths:
       parameters:
       - name: name
         in: query
-        description: 존재하지 않는 상품명
-        required: true
+        description: 상품명 (부분 검색)
+        required: false
         schema:
           type: string
       - name: intensityId
@@ -371,25 +458,85 @@ paths:
               schema:
                 $ref: "#/components/schemas/products-1886796052"
               examples:
-                상품_검색_결과_없음:
-                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ ],\r\n    \"\
-                    page\" : 0,\r\n    \"size\" : 20,\r\n    \"totalPages\" : 0,\r\
-                    \n    \"totalElements\" : 0\r\n  },\r\n  \"error\" : null\r\n}"
                 상품_목록_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
-                    id\" : 1,\r\n      \"name\" : \"콜드브루\",\r\n      \"price\" : 3500,\r\
-                    \n      \"quantity\" : 100,\r\n      \"thumbnail\" : \"https://test.com/thumbnail.png\"\
-                    ,\r\n      \"detailImage\" : \"https://test.com/detail.png\",\r\
-                    \n      \"intensity\" : \"Strong\",\r\n      \"cupSize\" : \"\
-                    Large\",\r\n      \"isSoldOut\" : false\r\n    }, {\r\n      \"\
-                    id\" : 2,\r\n      \"name\" : \"아메리카노\",\r\n      \"price\" :\
-                    \ 3000,\r\n      \"quantity\" : 150,\r\n      \"thumbnail\" :\
-                    \ \"https://test.com/americano.png\",\r\n      \"detailImage\"\
-                    \ : \"https://test.com/americano-detail.png\",\r\n      \"intensity\"\
-                    \ : \"Medium\",\r\n      \"cupSize\" : \"Small\",\r\n      \"\
-                    isSoldOut\" : false\r\n    } ],\r\n    \"page\" : 0,\r\n    \"\
-                    size\" : 20,\r\n    \"totalPages\" : 1,\r\n    \"totalElements\"\
-                    \ : 2\r\n  },\r\n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "content" : [ {
+                          "id" : 1,
+                          "name" : "콜드브루",
+                          "price" : 3500,
+                          "quantity" : 100,
+                          "thumbnail" : "https://test.com/thumbnail.png",
+                          "detailImage" : "https://test.com/detail.png",
+                          "intensity" : "Strong",
+                          "cupSize" : "Large",
+                          "isSoldOut" : false
+                        }, {
+                          "id" : 2,
+                          "name" : "아메리카노",
+                          "price" : 3000,
+                          "quantity" : 150,
+                          "thumbnail" : "https://test.com/americano.png",
+                          "detailImage" : "https://test.com/americano-detail.png",
+                          "intensity" : "Medium",
+                          "cupSize" : "Small",
+                          "isSoldOut" : false
+                        } ],
+                        "page" : 0,
+                        "size" : 20,
+                        "totalPages" : 1,
+                        "totalElements" : 2
+                      },
+                      "error" : null
+                    }
+                상품_검색_결과_없음:
+                  value: |-
+                    {
+                      "data" : {
+                        "content" : [ ],
+                        "page" : 0,
+                        "size" : 20,
+                        "totalPages" : 0,
+                        "totalElements" : 0
+                      },
+                      "error" : null
+                    }
+  /products/categories:
+    get:
+      tags:
+      - Product
+      summary: 상품 카테고리 목록을 조회할 수 있다.
+      operationId: 카테고리_목록_조회_성공
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/products-categories466113931"
+              examples:
+                카테고리_목록_조회_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "cupSizes" : [ {
+                          "id" : "1",
+                          "label" : "25ml"
+                        }, {
+                          "id" : "2",
+                          "label" : "80ml"
+                        } ],
+                        "intensities" : [ {
+                          "id" : "3",
+                          "label" : "1"
+                        }, {
+                          "id" : "4",
+                          "label" : "2"
+                        } ]
+                      },
+                      "error" : null
+                    }
   /products/{productId}:
     get:
       tags:
@@ -412,12 +559,20 @@ paths:
                 $ref: "#/components/schemas/products-productId-988628468"
               examples:
                 상품_상세_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"id\" : 1,\r\n    \"name\" :\
-                    \ \"콜드브루\",\r\n    \"price\" : 3500,\r\n    \"quantity\" : 100,\r\
-                    \n    \"thumbnail\" : \"https://test.com/thumbnail.png\",\r\n\
-                    \    \"detailImage\" : \"https://test.com/detail.png\",\r\n  \
-                    \  \"intensity\" : \"Strong\",\r\n    \"cupSize\" : \"Large\"\r\
-                    \n  },\r\n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "id" : 1,
+                        "name" : "콜드브루",
+                        "price" : 3500,
+                        "quantity" : 100,
+                        "thumbnail" : "https://test.com/thumbnail.png",
+                        "detailImage" : "https://test.com/detail.png",
+                        "intensity" : "Strong",
+                        "cupSize" : "Large"
+                      },
+                      "error" : null
+                    }
   /products/{productId}/reviews:
     get:
       tags:
@@ -446,14 +601,26 @@ paths:
                 $ref: "#/components/schemas/products-productId-reviews-352554938"
               examples:
                 상품_리뷰목록_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
-                    reviewId\" : 1,\r\n      \"rating\" : 5,\r\n      \"content\"\
-                    \ : \"아주 만족해요\",\r\n      \"createdAt\" : \"2025-06-01T12:00\"\
-                    ,\r\n      \"adminReply\" : {\r\n        \"content\" : \"감사합니다\
-                    \",\r\n        \"createdAt\" : \"2025-06-01T12:00\"\r\n      }\r\
-                    \n    } ],\r\n    \"page\" : 1,\r\n    \"size\" : 10,\r\n    \"\
-                    totalPages\" : 2,\r\n    \"totalElements\" : 11\r\n  },\r\n  \"\
-                    error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "content" : [ {
+                          "reviewId" : 1,
+                          "rating" : 5,
+                          "content" : "아주 만족해요",
+                          "createdAt" : "2025-06-01T12:00",
+                          "adminReply" : {
+                            "content" : "감사합니다",
+                            "createdAt" : "2025-06-01T12:00"
+                          }
+                        } ],
+                        "page" : 1,
+                        "size" : 10,
+                        "totalPages" : 2,
+                        "totalElements" : 11
+                      },
+                      "error" : null
+                    }
   /products/{productId}/reviews/rating:
     get:
       tags:
@@ -476,12 +643,21 @@ paths:
                 $ref: "#/components/schemas/products-productId-reviews-rating-66572293"
               examples:
                 상품_리뷰별점통계_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"averageRating\" : 3.5,\r\n\
-                    \    \"totalCount\" : 10,\r\n    \"ratingDistribution\" : {\r\n\
-                    \      \"oneStarCount\" : 2,\r\n      \"twoStarsCount\" : 3,\r\
-                    \n      \"threeStarsCount\" : 5,\r\n      \"fourStarsCount\" :\
-                    \ 1,\r\n      \"fiveStarsCount\" : 8\r\n    }\r\n  },\r\n  \"\
-                    error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "averageRating" : 3.5,
+                        "totalCount" : 10,
+                        "ratingDistribution" : {
+                          "oneStarCount" : 2,
+                          "twoStarsCount" : 3,
+                          "threeStarsCount" : 5,
+                          "fourStarsCount" : 1,
+                          "fiveStarsCount" : 8
+                        }
+                      },
+                      "error" : null
+                    }
   /reviews:
     post:
       tags:
@@ -503,8 +679,13 @@ paths:
               $ref: "#/components/schemas/reviews1890941445"
             examples:
               리뷰_등록_성공:
-                value: "{\r\n  \"orderNumber\" : \"ORDER1234\",\r\n  \"orderItemId\"\
-                  \ : 10,\r\n  \"rating\" : 3,\r\n  \"content\" : \"좋습니다.\"\r\n}"
+                value: |-
+                  {
+                    "orderNumber" : "ORDER1234",
+                    "orderItemId" : 10,
+                    "rating" : 3,
+                    "content" : "좋습니다."
+                  }
       responses:
         "200":
           description: "200"
@@ -514,8 +695,13 @@ paths:
                 $ref: "#/components/schemas/reviews-1411419170"
               examples:
                 리뷰_등록_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"reviewId\" : 10\r\n  },\r\n\
-                    \  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "reviewId" : 10
+                      },
+                      "error" : null
+                    }
   /reviews/{reviewId}:
     put:
       tags:
@@ -543,7 +729,11 @@ paths:
               $ref: "#/components/schemas/reviews-reviewId480882763"
             examples:
               리뷰_수정_성공:
-                value: "{\r\n  \"rating\" : 3,\r\n  \"content\" : \"좋습니다.\"\r\n}"
+                value: |-
+                  {
+                    "rating" : 3,
+                    "content" : "좋습니다."
+                  }
       responses:
         "200":
           description: "200"
@@ -553,8 +743,13 @@ paths:
                 $ref: "#/components/schemas/reviews-reviewId-215377401"
               examples:
                 리뷰_수정_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"reviewId\" : 10\r\n  },\r\n\
-                    \  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "reviewId" : 10
+                      },
+                      "error" : null
+                    }
     delete:
       tags:
       - Review
@@ -580,11 +775,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/carts-delete1686665306"
+                $ref: "#/components/schemas/admin-products-productId1686665306"
               examples:
                 리뷰_삭제_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
-                    \n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "message" : "OK"
+                      },
+                      "error" : null
+                    }
   /users/addresses:
     get:
       tags:
@@ -608,12 +808,20 @@ paths:
                 $ref: "#/components/schemas/users-addresses1010895288"
               examples:
                 배송지_목록조회_성공:
-                  value: "{\r\n  \"data\" : [ {\r\n    \"addressId\" : 1,\r\n    \"\
-                    alias\" : \"집\",\r\n    \"recipientName\" : \"홍길동\",\r\n    \"\
-                    recipientPhone\" : \"010-1234-5678\",\r\n    \"zipCode\" : \"\
-                    12345\",\r\n    \"address1\" : \"서울시 강남구 테헤란로 123\",\r\n    \"\
-                    address2\" : \"A동 101호\",\r\n    \"isDefault\" : true\r\n  } ],\r\
-                    \n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : [ {
+                        "addressId" : 1,
+                        "alias" : "집",
+                        "recipientName" : "홍길동",
+                        "recipientPhone" : "010-1234-5678",
+                        "zipCode" : "12345",
+                        "address1" : "서울시 강남구 테헤란로 123",
+                        "address2" : "A동 101호",
+                        "isDefault" : true
+                      } ],
+                      "error" : null
+                    }
     post:
       tags:
       - Address
@@ -634,10 +842,16 @@ paths:
               $ref: "#/components/schemas/users-addresses135049666"
             examples:
               배송지_등록_성공:
-                value: "{\r\n  \"alias\" : \"회사\",\r\n  \"recipientName\" : \"홍길동\"\
-                  ,\r\n  \"recipientPhone\" : \"010-1234-1234\",\r\n  \"zipCode\"\
-                  \ : \"08123\",\r\n  \"address1\" : \"서울특별시 관악구\",\r\n  \"address2\"\
-                  \ : \"123동 123호\",\r\n  \"isDefault\" : true\r\n}"
+                value: |-
+                  {
+                    "alias" : "회사",
+                    "recipientName" : "홍길동",
+                    "recipientPhone" : "010-1234-1234",
+                    "zipCode" : "08123",
+                    "address1" : "서울특별시 관악구",
+                    "address2" : "123동 123호",
+                    "isDefault" : true
+                  }
       responses:
         "200":
           description: "200"
@@ -647,8 +861,13 @@ paths:
                 $ref: "#/components/schemas/users-addresses414680085"
               examples:
                 배송지_등록_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"addressId\" : 10\r\n  },\r\n\
-                    \  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "addressId" : 10
+                      },
+                      "error" : null
+                    }
   /users/addresses/default:
     get:
       tags:
@@ -671,17 +890,33 @@ paths:
               schema:
                 $ref: "#/components/schemas/users-addresses-default772693087"
               examples:
-                기본배송지_없음:
-                  value: "{\r\n  \"data\" : {\r\n    \"hasDefault\" : false,\r\n \
-                    \   \"address\" : null\r\n  },\r\n  \"error\" : null\r\n}"
                 기본배송지_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"hasDefault\" : true,\r\n  \
-                    \  \"address\" : {\r\n      \"addressId\" : 1,\r\n      \"alias\"\
-                    \ : \"집\",\r\n      \"recipientName\" : \"홍길동\",\r\n      \"recipientPhone\"\
-                    \ : \"010-1234-5678\",\r\n      \"zipCode\" : \"12345\",\r\n \
-                    \     \"address1\" : \"서울시 강남구 테헤란로 123\",\r\n      \"address2\"\
-                    \ : \"A동 101호\",\r\n      \"isDefault\" : true\r\n    }\r\n  },\r\
-                    \n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "hasDefault" : true,
+                        "address" : {
+                          "addressId" : 1,
+                          "alias" : "집",
+                          "recipientName" : "홍길동",
+                          "recipientPhone" : "010-1234-5678",
+                          "zipCode" : "12345",
+                          "address1" : "서울시 강남구 테헤란로 123",
+                          "address2" : "A동 101호",
+                          "isDefault" : true
+                        }
+                      },
+                      "error" : null
+                    }
+                기본배송지_없음:
+                  value: |-
+                    {
+                      "data" : {
+                        "hasDefault" : false,
+                        "address" : null
+                      },
+                      "error" : null
+                    }
   /users/addresses/{addressId}:
     put:
       tags:
@@ -709,10 +944,16 @@ paths:
               $ref: "#/components/schemas/users-addresses135049666"
             examples:
               배송지_수정_성공:
-                value: "{\r\n  \"alias\" : \"회사\",\r\n  \"recipientName\" : \"홍길동\"\
-                  ,\r\n  \"recipientPhone\" : \"010-1234-1234\",\r\n  \"zipCode\"\
-                  \ : \"08123\",\r\n  \"address1\" : \"서울특별시 관악구\",\r\n  \"address2\"\
-                  \ : \"123동 123호\",\r\n  \"isDefault\" : true\r\n}"
+                value: |-
+                  {
+                    "alias" : "회사",
+                    "recipientName" : "홍길동",
+                    "recipientPhone" : "010-1234-1234",
+                    "zipCode" : "08123",
+                    "address1" : "서울특별시 관악구",
+                    "address2" : "123동 123호",
+                    "isDefault" : true
+                  }
       responses:
         "200":
           description: "200"
@@ -722,8 +963,13 @@ paths:
                 $ref: "#/components/schemas/users-addresses414680085"
               examples:
                 배송지_수정_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"addressId\" : 10\r\n  },\r\n\
-                    \  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "addressId" : 10
+                      },
+                      "error" : null
+                    }
     delete:
       tags:
       - Address
@@ -749,11 +995,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/carts-delete1686665306"
+                $ref: "#/components/schemas/admin-products-productId1686665306"
               examples:
                 배송지_삭제_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
-                    \n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "message" : "OK"
+                      },
+                      "error" : null
+                    }
   /users/addresses/{userAddressId}:
     get:
       tags:
@@ -783,12 +1034,20 @@ paths:
                 $ref: "#/components/schemas/users-addresses-userAddressId133936271"
               examples:
                 배송지_조회_성공:
-                  value: "{\r\n  \"data\" : {\r\n    \"addressId\" : 1,\r\n    \"\
-                    alias\" : \"집\",\r\n    \"recipientName\" : \"홍길동\",\r\n    \"\
-                    recipientPhone\" : \"010-1234-5678\",\r\n    \"zipCode\" : \"\
-                    12345\",\r\n    \"address1\" : \"서울시 강남구 테헤란로 123\",\r\n    \"\
-                    address2\" : \"A동 101호\",\r\n    \"isDefault\" : true\r\n  },\r\
-                    \n  \"error\" : null\r\n}"
+                  value: |-
+                    {
+                      "data" : {
+                        "addressId" : 1,
+                        "alias" : "집",
+                        "recipientName" : "홍길동",
+                        "recipientPhone" : "010-1234-5678",
+                        "zipCode" : "12345",
+                        "address1" : "서울시 강남구 테헤란로 123",
+                        "address2" : "A동 101호",
+                        "isDefault" : true
+                      },
+                      "error" : null
+                    }
 components:
   schemas:
     reviews-1411419170:
@@ -802,6 +1061,45 @@ components:
             reviewId:
               type: number
               description: 생성된 리뷰 아이디
+    products-categories466113931:
+      type: object
+      properties:
+        data:
+          required:
+          - cupSizes
+          - intensities
+          type: object
+          properties:
+            cupSizes:
+              type: array
+              description: 컵 사이즈 목록
+              items:
+                required:
+                - id
+                - label
+                type: object
+                properties:
+                  label:
+                    type: string
+                    description: 카테고리명
+                  id:
+                    type: string
+                    description: 카테고리 ID
+            intensities:
+              type: array
+              description: 원두 강도 목록
+              items:
+                required:
+                - id
+                - label
+                type: object
+                properties:
+                  label:
+                    type: string
+                    description: 카테고리명
+                  id:
+                    type: string
+                    description: 카테고리 ID
     carts-delete1623445193:
       required:
       - cartItemIds
@@ -962,7 +1260,7 @@ components:
                   type: number
                   description: 배송지 ID
               description: 기본 배송지
-    carts-delete1686665306:
+    admin-products-productId1686665306:
       type: object
       properties:
         data:
@@ -1122,17 +1420,6 @@ components:
         detailImage:
           type: string
           description: 상세 이미지
-    users-addresses414680085:
-      type: object
-      properties:
-        data:
-          required:
-          - addressId
-          type: object
-          properties:
-            addressId:
-              type: number
-              description: 배송지 아이디
     reviews-reviewId480882763:
       required:
       - content
@@ -1145,6 +1432,17 @@ components:
         content:
           type: string
           description: 리뷰 내용
+    users-addresses414680085:
+      type: object
+      properties:
+        data:
+          required:
+          - addressId
+          type: object
+          properties:
+            addressId:
+              type: number
+              description: 배송지 아이디
     products-1886796052:
       type: object
       properties:
@@ -1430,6 +1728,22 @@ components:
               addressId:
                 type: number
                 description: 배송지 ID
+    cart-items367995349:
+      required:
+      - cartId
+      - productId
+      - quantity
+      type: object
+      properties:
+        quantity:
+          type: number
+          description: 수량
+        productId:
+          type: number
+          description: 상품 아이디
+        cartId:
+          type: number
+          description: 카트 아이디
     products-productId-reviews-352554938:
       type: object
       properties:
@@ -1486,22 +1800,17 @@ components:
             totalElements:
               type: number
               description: 총 수
-    cart-items367995349:
-      required:
-      - cartId
-      - productId
-      - quantity
+    admin-products-productId-1712578160:
       type: object
       properties:
-        quantity:
-          type: number
-          description: 수량
-        productId:
-          type: number
-          description: 상품 아이디
-        cartId:
-          type: number
-          description: 카트 아이디
+        data:
+          required:
+          - productId
+          type: object
+          properties:
+            productId:
+              type: number
+              description: 수정된 상품 아이디
     cart-items1349440338:
       required:
       - productId
@@ -1514,14 +1823,3 @@ components:
         productId:
           type: number
           description: 상품Id
-    admin-products-productId-1712578160:
-      type: object
-      properties:
-        data:
-          required:
-          - productId
-          type: object
-          properties:
-            productId:
-              type: number
-              description: 수정된 상품 아이디

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
@@ -1,8 +1,10 @@
 package com.fastcampus.commerce.product.application
 
 import com.fastcampus.commerce.product.application.request.SearchProductRequest
+import com.fastcampus.commerce.product.application.response.CategoryResponse
 import com.fastcampus.commerce.product.application.response.ProductDetailResponse
 import com.fastcampus.commerce.product.application.response.SearchProductResponse
+import com.fastcampus.commerce.product.domain.model.CategoryDetail
 import com.fastcampus.commerce.product.domain.model.ProductCategoryInfo
 import com.fastcampus.commerce.product.domain.service.CategoryReader
 import com.fastcampus.commerce.product.domain.service.ProductReader
@@ -15,6 +17,11 @@ class ProductQueryService(
     private val productReader: ProductReader,
     private val categoryReader: CategoryReader,
 ) {
+    fun getCategories(): List<CategoryResponse> {
+        val categories: List<CategoryDetail> = categoryReader.getCategoryDetail()
+        return categories.map(CategoryResponse::from)
+    }
+
     fun getProducts(request: SearchProductRequest, pageable: Pageable): Page<SearchProductResponse> {
         val productInfos = productReader.searchProducts(request.toCondition(), pageable)
         val productIds = productInfos.content.map { it.id }

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/response/CategoryResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/response/CategoryResponse.kt
@@ -1,0 +1,18 @@
+package com.fastcampus.commerce.product.application.response
+
+import com.fastcampus.commerce.product.domain.model.CategoryDetail
+
+data class CategoryResponse(
+    val groupTitle: String,
+    val id: Long,
+    val name: String,
+) {
+    companion object {
+        fun from(categoryDetail: CategoryDetail) =
+            CategoryResponse(
+                groupTitle = categoryDetail.groupTitle,
+                id = categoryDetail.categoryId,
+                name = categoryDetail.categoryName,
+            )
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/model/CategoryDetail.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/model/CategoryDetail.kt
@@ -1,0 +1,13 @@
+package com.fastcampus.commerce.product.domain.model
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class CategoryDetail
+    @QueryProjection
+    constructor(
+        val groupId: Long,
+        val groupTitle: String,
+        val categoryId: Long,
+        val categoryName: String,
+        val sortOrder: Int,
+    )

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/CategoryRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/CategoryRepository.kt
@@ -1,5 +1,9 @@
 package com.fastcampus.commerce.product.domain.repository
 
+import com.fastcampus.commerce.product.domain.model.CategoryDetail
+
 interface CategoryRepository {
     fun countCategoriesByIds(categoryIds: List<Long>): Long
+
+    fun getCategoryDetail(): List<CategoryDetail>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/CategoryReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/CategoryReader.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.product.domain.service
 
 import com.fastcampus.commerce.product.domain.entity.ProductCategory
+import com.fastcampus.commerce.product.domain.model.CategoryDetail
 import com.fastcampus.commerce.product.domain.model.CategoryType
 import com.fastcampus.commerce.product.domain.model.ProductCategoryInfo
 import com.fastcampus.commerce.product.domain.repository.CategoryRepository
@@ -33,5 +34,9 @@ class CategoryReader(
 
     fun getProductCategory(productId: Long): ProductCategoryInfo {
         return getProductCategoryMap(listOf(productId))[productId] ?: ProductCategoryInfo.empty()
+    }
+
+    fun getCategoryDetail(): List<CategoryDetail> {
+        return categoryRepository.getCategoryDetail()
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/CategoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/infrastructure/CategoryRepositoryImpl.kt
@@ -1,13 +1,36 @@
 package com.fastcampus.commerce.product.infrastructure
 
+import com.fastcampus.commerce.product.domain.entity.QCategory.category
+import com.fastcampus.commerce.product.domain.entity.QCategoryGroup.categoryGroup
+import com.fastcampus.commerce.product.domain.model.CategoryDetail
+import com.fastcampus.commerce.product.domain.model.QCategoryDetail
 import com.fastcampus.commerce.product.domain.repository.CategoryRepository
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 
 @Repository
 class CategoryRepositoryImpl(
     private val categoryJpaRepository: CategoryJpaRepository,
+    private val queryFactory: JPAQueryFactory,
 ) : CategoryRepository {
     override fun countCategoriesByIds(categoryIds: List<Long>): Long {
         return categoryJpaRepository.countCategoriesByIdIn(categoryIds)
+    }
+
+    override fun getCategoryDetail(): List<CategoryDetail> {
+        return queryFactory
+            .select(
+                QCategoryDetail(
+                    categoryGroup.id,
+                    categoryGroup.title,
+                    category.id,
+                    category.name,
+                    category.sortOrder,
+                ),
+            )
+            .from(category)
+            .join(categoryGroup).on(category.groupId.eq(categoryGroup.id))
+            .orderBy(categoryGroup.id.asc(), category.sortOrder.asc())
+            .fetch()
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/interfaces/ProductController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/interfaces/ProductController.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.interfaces
 import com.fastcampus.commerce.common.response.PagedData
 import com.fastcampus.commerce.product.application.ProductQueryService
 import com.fastcampus.commerce.product.interfaces.request.SearchProductApiRequest
+import com.fastcampus.commerce.product.interfaces.response.CategoryApiResponse
 import com.fastcampus.commerce.product.interfaces.response.ProductDetailApiResponse
 import com.fastcampus.commerce.product.interfaces.response.SearchProductApiResponse
 import org.springframework.data.domain.Pageable
@@ -18,6 +19,12 @@ import org.springframework.web.bind.annotation.RestController
 class ProductController(
     private val productQueryService: ProductQueryService,
 ) {
+    @GetMapping("/categories")
+    fun getCategories(): CategoryApiResponse {
+        val categoryResponses = productQueryService.getCategories()
+        return CategoryApiResponse.from(categoryResponses)
+    }
+
     @GetMapping
     fun searchProducts(
         @ModelAttribute request: SearchProductApiRequest,

--- a/src/main/kotlin/com/fastcampus/commerce/product/interfaces/response/CategoryApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/interfaces/response/CategoryApiResponse.kt
@@ -1,0 +1,30 @@
+package com.fastcampus.commerce.product.interfaces.response
+
+import com.fastcampus.commerce.common.response.CodeResponse
+import com.fastcampus.commerce.product.application.response.CategoryResponse
+import com.fastcampus.commerce.product.domain.model.CategoryType
+
+data class CategoryApiResponse(
+    val cupSizes: List<CodeResponse>,
+    val intensities: List<CodeResponse>,
+) {
+    companion object {
+        fun from(categoryResponses: List<CategoryResponse>): CategoryApiResponse {
+            return categoryResponses.toCategoryApiResponse()
+        }
+
+        private fun List<CategoryResponse>.toCategoryApiResponse(): CategoryApiResponse {
+            val grouped = groupBy { it.groupTitle }
+            return CategoryApiResponse(
+                cupSizes = grouped.getCodeResponses(CategoryType.CUP_SIZE),
+                intensities = grouped.getCodeResponses(CategoryType.INTENSITY),
+            )
+        }
+
+        private fun Map<String, List<CategoryResponse>>.getCodeResponses(categoryType: CategoryType): List<CodeResponse> {
+            return this[categoryType.groupTitle]
+                ?.map { CodeResponse(id = it.id.toString(), label = it.name) }
+                ?: emptyList()
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,8 +8,7 @@ spring:
       - classpath:config/file.yml
       - classpath:config/logging.yml
       - classpath:config/web.yml
-      - classpath:config/secret/auth.yml
-      - classpath:config/secret/db.yml
+      - classpath:config/auth.yml
   web:
     resources:
       static-locations:

--- a/src/main/resources/config/auth.yml
+++ b/src/main/resources/config/auth.yml
@@ -1,0 +1,19 @@
+auth:
+  jwt:
+    issuer: fastcampus-commerce
+    #    secret: ${SECRET_KEY}
+    secret: L1YzcO5NW5wOfD2O9Gke7+blGE1FdnOiL0klgjCgvHhDOjD8/c2c/R5Tn867m/rp4kyBQn/L6HjrtevIjF/QeA==
+    access-token-expire-minutes: 30 # 30분
+    refresh-token-expire-days: 14   # 2주
+
+  oauth2:
+    naver:
+      client-id: OFAjwhciHWlXDEPTzYGW
+      #      client-secret: 1MF0BuXZ31
+      client-secret: MU1GMEJ1WFozMQ==
+      redirect-uri: http://3.39.233.3:8080/login/oauth2/code/naver
+      authorization-grant-type: authorization_code
+      scope:
+        - name
+        - email
+        - profile_image

--- a/src/main/resources/config/db.yml
+++ b/src/main/resources/config/db.yml
@@ -24,6 +24,6 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/commerce
-    username: ${secrets.db.username}
-    password: ${secrets.db.password}
+    username: commerce
+    password: aa
 

--- a/src/test/kotlin/com/fastcampus/commerce/product/application/ProductQueryServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/application/ProductQueryServiceTest.kt
@@ -1,7 +1,9 @@
 package com.fastcampus.commerce.product.application
 
 import com.fastcampus.commerce.product.application.request.SearchProductRequest
+import com.fastcampus.commerce.product.application.response.CategoryResponse
 import com.fastcampus.commerce.product.application.response.SearchProductResponse
+import com.fastcampus.commerce.product.domain.model.CategoryDetail
 import com.fastcampus.commerce.product.domain.model.ProductCategoryInfo
 import com.fastcampus.commerce.product.domain.model.ProductInfo
 import com.fastcampus.commerce.product.domain.model.SearchProductCondition
@@ -27,6 +29,66 @@ class ProductQueryServiceTest : DescribeSpec(
 
         beforeTest {
             clearMocks(productReader, categoryReader)
+        }
+
+        describe("카테고리 목록 조회") {
+            context("정상 조회") {
+                it("전체 카테고리 목록을 조회할 수 있다") {
+                    val categoryDetails = listOf(
+                        CategoryDetail(
+                            groupId = 1L,
+                            groupTitle = "cup_size",
+                            categoryId = 1L,
+                            categoryName = "Small",
+                            sortOrder = 1,
+                        ),
+                        CategoryDetail(
+                            groupId = 1L,
+                            groupTitle = "cup_size",
+                            categoryId = 2L,
+                            categoryName = "Large",
+                            sortOrder = 2,
+                        ),
+                        CategoryDetail(
+                            groupId = 2L,
+                            groupTitle = "intensity",
+                            categoryId = 3L,
+                            categoryName = "Mild",
+                            sortOrder = 1,
+                        ),
+                        CategoryDetail(
+                            groupId = 2L,
+                            groupTitle = "intensity",
+                            categoryId = 4L,
+                            categoryName = "Strong",
+                            sortOrder = 2,
+                        ),
+                    )
+
+                    every { categoryReader.getCategoryDetail() } returns categoryDetails
+
+                    val result = productQueryService.getCategories()
+
+                    result shouldBe listOf(
+                        CategoryResponse(groupTitle = "cup_size", id = 1L, name = "Small"),
+                        CategoryResponse(groupTitle = "cup_size", id = 2L, name = "Large"),
+                        CategoryResponse(groupTitle = "intensity", id = 3L, name = "Mild"),
+                        CategoryResponse(groupTitle = "intensity", id = 4L, name = "Strong"),
+                    )
+
+                    verify(exactly = 1) { categoryReader.getCategoryDetail() }
+                }
+
+                it("카테고리가 없는 경우 빈 리스트를 반환한다") {
+                    every { categoryReader.getCategoryDetail() } returns emptyList()
+
+                    val result = productQueryService.getCategories()
+
+                    result shouldBe emptyList()
+
+                    verify(exactly = 1) { categoryReader.getCategoryDetail() }
+                }
+            }
         }
 
         describe("상품 목록 조회") {

--- a/src/test/kotlin/com/fastcampus/commerce/product/interfaces/ProductControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/interfaces/ProductControllerRestDocTest.kt
@@ -2,6 +2,7 @@ package com.fastcampus.commerce.product.interfaces
 
 import com.fastcampus.commerce.config.TestSecurityConfig
 import com.fastcampus.commerce.product.application.ProductQueryService
+import com.fastcampus.commerce.product.application.response.CategoryResponse
 import com.fastcampus.commerce.product.application.response.ProductDetailResponse
 import com.fastcampus.commerce.product.application.response.SearchProductResponse
 import com.fastcampus.commerce.restdoc.documentation
@@ -38,6 +39,55 @@ class ProductControllerRestDocTest : DescribeSpec() {
     init {
         beforeSpec {
             RestAssuredMockMvc.mockMvc(mockMvc)
+        }
+
+        describe("GET /products/categories - 카테고리 목록 조회") {
+            val summary = "상품 카테고리 목록을 조회할 수 있다."
+
+            it("전체 카테고리 목록을 조회할 수 있다.") {
+                val categoryResponses = listOf(
+                    CategoryResponse(groupTitle = "cup_size", id = 1L, name = "25ml"),
+                    CategoryResponse(groupTitle = "cup_size", id = 2L, name = "80ml"),
+                    CategoryResponse(groupTitle = "intensity", id = 3L, name = "1"),
+                    CategoryResponse(groupTitle = "intensity", id = 4L, name = "2"),
+                )
+
+                every {
+                    productQueryService.getCategories()
+                } returns categoryResponses
+
+                documentation(
+                    identifier = "카테고리_목록_조회_성공",
+                    tag = tag,
+                    summary = summary,
+                ) {
+                    requestLine(HttpMethod.GET, "/products/categories")
+
+                    responseBody {
+                        field(
+                            "data.cupSizes",
+                            "컵 사이즈 목록",
+                            listOf(
+                                mapOf("id" to "1", "label" to "25ml"),
+                                mapOf("id" to "2", "label" to "80ml"),
+                            ),
+                        )
+                        field("data.cupSizes[0].id", "카테고리 ID", "1")
+                        field("data.cupSizes[0].label", "카테고리명", "25ml")
+                        field(
+                            "data.intensities",
+                            "원두 강도 목록",
+                            listOf(
+                                mapOf("id" to "3", "label" to "1"),
+                                mapOf("id" to "4", "label" to "2"),
+                            ),
+                        )
+                        field("data.intensities[0].id", "카테고리 ID", "3")
+                        field("data.intensities[0].label", "카테고리명", "1")
+                        ignoredField("error")
+                    }
+                }
+            }
         }
 
         describe("GET /products - 상품 목록 조회") {


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
- 상품 카테고리 목록 조회 API 추가
---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #70 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->