### PR TITLE
[feat] 관리자 상품 검색/조회 API + 메인 상품 API 껍데기

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
@@ -1,14 +1,19 @@
 package com.fastcampus.commerce.admin.product.application
 
 import com.fastcampus.commerce.admin.product.application.request.RegisterProductRequest
+import com.fastcampus.commerce.admin.product.application.request.SearchAdminProductRequest
 import com.fastcampus.commerce.admin.product.application.request.UpdateProductRequest
+import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
 import com.fastcampus.commerce.admin.product.application.response.SellingStatusResponse
 import com.fastcampus.commerce.common.error.CommonErrorCode
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.file.application.FileCommandService
 import com.fastcampus.commerce.file.domain.service.UploadedFileVerifier
 import com.fastcampus.commerce.product.application.ProductCommandService
+import com.fastcampus.commerce.product.application.ProductQueryService
 import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 
@@ -16,6 +21,7 @@ import org.springframework.transaction.support.TransactionTemplate
 class AdminProductService(
     private val uploadedFileVerifier: UploadedFileVerifier,
     private val productCommandService: ProductCommandService,
+    private val productQueryService: ProductQueryService,
     private val fileCommandService: FileCommandService,
     private val transactionTemplate: TransactionTemplate,
 ) {
@@ -58,5 +64,10 @@ class AdminProductService(
         transactionTemplate.execute {
             productCommandService.deleteProduct(productId)
         }
+    }
+
+    fun searchProducts(request: SearchAdminProductRequest, pageable: Pageable): Page<SearchAdminProductResponse> {
+        val products = productQueryService.searchProductsForAdmin(request, pageable)
+        return products
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductService.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.admin.product.application
 import com.fastcampus.commerce.admin.product.application.request.RegisterProductRequest
 import com.fastcampus.commerce.admin.product.application.request.SearchAdminProductRequest
 import com.fastcampus.commerce.admin.product.application.request.UpdateProductRequest
+import com.fastcampus.commerce.admin.product.application.response.AdminProductDetailResponse
 import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
 import com.fastcampus.commerce.admin.product.application.response.SellingStatusResponse
 import com.fastcampus.commerce.common.error.CommonErrorCode
@@ -69,5 +70,9 @@ class AdminProductService(
     fun searchProducts(request: SearchAdminProductRequest, pageable: Pageable): Page<SearchAdminProductResponse> {
         val products = productQueryService.searchProductsForAdmin(request, pageable)
         return products
+    }
+
+    fun getProduct(productId: Long): AdminProductDetailResponse {
+        return productQueryService.getProductDetailForAdmin(productId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/SearchAdminProductRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/request/SearchAdminProductRequest.kt
@@ -1,0 +1,18 @@
+package com.fastcampus.commerce.admin.product.application.request
+
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import com.fastcampus.commerce.product.domain.model.SearchAdminProductCondition
+
+data class SearchAdminProductRequest(
+    val name: String? = null,
+    val intensityId: Long? = null,
+    val cupSizeId: Long? = null,
+    val status: SellingStatus? = null,
+) {
+    fun toCondition() =
+        SearchAdminProductCondition(
+            name = name,
+            categories = listOfNotNull(intensityId, cupSizeId),
+            status = status,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/response/AdminProductDetailResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/response/AdminProductDetailResponse.kt
@@ -4,24 +4,26 @@ import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.model.ProductCategoryInfo
 import com.fastcampus.commerce.product.domain.model.ProductInfo
 
-data class SearchAdminProductResponse(
+data class AdminProductDetailResponse(
     val id: Long,
     val name: String,
     val price: Int,
     val quantity: Int,
     val thumbnail: String,
+    val detailImage: String,
     val intensity: String,
     val cupSize: String,
     val status: SellingStatus,
 ) {
     companion object {
-        fun of(productInfo: ProductInfo, productCategoryInfo: ProductCategoryInfo): SearchAdminProductResponse {
-            return SearchAdminProductResponse(
+        fun of(productInfo: ProductInfo, productCategoryInfo: ProductCategoryInfo): AdminProductDetailResponse {
+            return AdminProductDetailResponse(
                 id = productInfo.id,
                 name = productInfo.name,
                 price = productInfo.price,
                 quantity = productInfo.quantity,
                 thumbnail = productInfo.thumbnail,
+                detailImage = productInfo.detailImage,
                 intensity = productCategoryInfo.intensity,
                 cupSize = productCategoryInfo.cupSize,
                 status = productInfo.status,

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/application/response/SearchAdminProductResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/application/response/SearchAdminProductResponse.kt
@@ -1,0 +1,31 @@
+package com.fastcampus.commerce.admin.product.application.response
+
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+import com.fastcampus.commerce.product.domain.model.ProductCategoryInfo
+import com.fastcampus.commerce.product.domain.model.ProductInfo
+
+data class SearchAdminProductResponse(
+    val id: Long,
+    val name: String,
+    val price: Int,
+    val thumbnail: String,
+    val status: SellingStatus,
+    val stock: Int,
+    val intensity: String,
+    val cupSize: String,
+) {
+    companion object {
+        fun of(productInfo: ProductInfo, productCategoryInfo: ProductCategoryInfo): SearchAdminProductResponse {
+            return SearchAdminProductResponse(
+                id = productInfo.id,
+                name = productInfo.name,
+                price = productInfo.price,
+                thumbnail = productInfo.thumbnail,
+                status = productInfo.status,
+                stock = productInfo.quantity,
+                intensity = productCategoryInfo.intensity,
+                cupSize = productCategoryInfo.cupSize,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
@@ -4,6 +4,7 @@ import com.fastcampus.commerce.admin.product.application.AdminProductService
 import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
 import com.fastcampus.commerce.admin.product.interfaces.request.SearchAdminProductApiRequest
 import com.fastcampus.commerce.admin.product.interfaces.request.UpdateProductApiRequest
+import com.fastcampus.commerce.admin.product.interfaces.response.AdminProductDetailApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.DeleteProductApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.RegisterProductApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.SearchAdminProductApiResponse
@@ -40,6 +41,13 @@ class AdminProductController(
     ): PagedData<SearchAdminProductApiResponse> {
         val products = adminProductService.searchProducts(request.toServiceRequest(), pageable)
         return PagedData.of(products.map(SearchAdminProductApiResponse::from))
+    }
+
+    @GetMapping("/{productId}")
+    fun getProduct(
+        @PathVariable productId: Long,
+    ): AdminProductDetailApiResponse {
+        return AdminProductDetailApiResponse.from(adminProductService.getProduct(productId))
     }
 
     @PostMapping

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductController.kt
@@ -2,13 +2,18 @@ package com.fastcampus.commerce.admin.product.interfaces
 
 import com.fastcampus.commerce.admin.product.application.AdminProductService
 import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
+import com.fastcampus.commerce.admin.product.interfaces.request.SearchAdminProductApiRequest
 import com.fastcampus.commerce.admin.product.interfaces.request.UpdateProductApiRequest
 import com.fastcampus.commerce.admin.product.interfaces.response.DeleteProductApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.RegisterProductApiResponse
+import com.fastcampus.commerce.admin.product.interfaces.response.SearchAdminProductApiResponse
 import com.fastcampus.commerce.admin.product.interfaces.response.UpdateProductApiResponse
 import com.fastcampus.commerce.common.response.EnumResponse
+import com.fastcampus.commerce.common.response.PagedData
+import org.springframework.data.domain.Pageable
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -26,6 +31,15 @@ class AdminProductController(
     fun getSellingStatus(): List<EnumResponse> {
         val sellingStatuses = adminProductService.getSellingStatus()
         return sellingStatuses.map { EnumResponse(it.code, it.label) }
+    }
+
+    @GetMapping
+    fun searchProducts(
+        @ModelAttribute request: SearchAdminProductApiRequest,
+        pageable: Pageable,
+    ): PagedData<SearchAdminProductApiResponse> {
+        val products = adminProductService.searchProducts(request.toServiceRequest(), pageable)
+        return PagedData.of(products.map(SearchAdminProductApiResponse::from))
     }
 
     @PostMapping

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/SearchAdminProductApiRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/SearchAdminProductApiRequest.kt
@@ -1,0 +1,19 @@
+package com.fastcampus.commerce.admin.product.interfaces.request
+
+import com.fastcampus.commerce.admin.product.application.request.SearchAdminProductRequest
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+
+data class SearchAdminProductApiRequest(
+    val name: String? = null,
+    val intensityId: Long? = null,
+    val cupSizeId: Long? = null,
+    val status: SellingStatus? = null,
+) {
+    fun toServiceRequest(): SearchAdminProductRequest =
+        SearchAdminProductRequest(
+            name = name,
+            intensityId = intensityId,
+            cupSizeId = cupSizeId,
+            status = status,
+        )
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/SearchProductApiRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/request/SearchProductApiRequest.kt
@@ -1,0 +1,10 @@
+package com.fastcampus.commerce.admin.product.interfaces.request
+
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+
+data class SearchProductApiRequest(
+    val name: String? = null,
+    val intensityId: Long? = null,
+    val cupSizeId: Long? = null,
+    val status: SellingStatus? = null,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/AdminProductDetailApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/AdminProductDetailApiResponse.kt
@@ -1,0 +1,31 @@
+package com.fastcampus.commerce.admin.product.interfaces.response
+
+import com.fastcampus.commerce.admin.product.application.response.AdminProductDetailResponse
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+
+data class AdminProductDetailApiResponse(
+    val id: Long,
+    val name: String,
+    val price: Int,
+    val quantity: Int,
+    val thumbnail: String,
+    val detailImage: String,
+    val intensity: String,
+    val cupSize: String,
+    val status: SellingStatus,
+) {
+    companion object {
+        fun from(product: AdminProductDetailResponse) =
+            AdminProductDetailApiResponse(
+                id = product.id,
+                name = product.name,
+                price = product.price,
+                quantity = product.quantity,
+                thumbnail = product.thumbnail,
+                detailImage = product.detailImage,
+                intensity = product.intensity,
+                cupSize = product.cupSize,
+                status = product.status,
+            )
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/SearchAdminProductApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/SearchAdminProductApiResponse.kt
@@ -7,11 +7,11 @@ data class SearchAdminProductApiResponse(
     val id: Long,
     val name: String,
     val price: Int,
+    val quantity: Int,
     val thumbnail: String,
-    val status: SellingStatus,
-    val stock: Int,
     val intensity: String,
     val cupSize: String,
+    val status: SellingStatus,
 ) {
     companion object {
         fun from(response: SearchAdminProductResponse): SearchAdminProductApiResponse =
@@ -19,11 +19,11 @@ data class SearchAdminProductApiResponse(
                 id = response.id,
                 name = response.name,
                 price = response.price,
+                quantity = response.quantity,
                 thumbnail = response.thumbnail,
-                status = response.status,
-                stock = response.stock,
                 intensity = response.intensity,
                 cupSize = response.cupSize,
+                status = response.status,
             )
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/SearchAdminProductApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/product/interfaces/response/SearchAdminProductApiResponse.kt
@@ -1,0 +1,29 @@
+package com.fastcampus.commerce.admin.product.interfaces.response
+
+import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+
+data class SearchAdminProductApiResponse(
+    val id: Long,
+    val name: String,
+    val price: Int,
+    val thumbnail: String,
+    val status: SellingStatus,
+    val stock: Int,
+    val intensity: String,
+    val cupSize: String,
+) {
+    companion object {
+        fun from(response: SearchAdminProductResponse): SearchAdminProductApiResponse =
+            SearchAdminProductApiResponse(
+                id = response.id,
+                name = response.name,
+                price = response.price,
+                thumbnail = response.thumbnail,
+                status = response.status,
+                stock = response.stock,
+                intensity = response.intensity,
+                cupSize = response.cupSize,
+            )
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
@@ -1,5 +1,7 @@
 package com.fastcampus.commerce.product.application
 
+import com.fastcampus.commerce.admin.product.application.request.SearchAdminProductRequest
+import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
 import com.fastcampus.commerce.product.application.request.SearchProductRequest
 import com.fastcampus.commerce.product.application.response.CategoryResponse
 import com.fastcampus.commerce.product.application.response.ProductDetailResponse
@@ -36,5 +38,15 @@ class ProductQueryService(
         val productInfo = productReader.getProductInfo(productId)
         val productCategoryInfo = categoryReader.getProductCategory(productId)
         return ProductDetailResponse.of(productInfo, productCategoryInfo)
+    }
+
+    fun searchProductsForAdmin(request: SearchAdminProductRequest, pageable: Pageable): Page<SearchAdminProductResponse> {
+        val productInfos = productReader.searchProductsForAdmin(request.toCondition(), pageable)
+        val productIds = productInfos.content.map { it.id }
+        val categoryMap = categoryReader.getProductCategoryMap(productIds)
+        return productInfos.map { productInfo ->
+            val productCategoryInfo = categoryMap[productInfo.id] ?: ProductCategoryInfo.empty()
+            SearchAdminProductResponse.of(productInfo, productCategoryInfo)
+        }
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.product.application
 
 import com.fastcampus.commerce.admin.product.application.request.SearchAdminProductRequest
+import com.fastcampus.commerce.admin.product.application.response.AdminProductDetailResponse
 import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
 import com.fastcampus.commerce.product.application.request.SearchProductRequest
 import com.fastcampus.commerce.product.application.response.CategoryResponse
@@ -48,5 +49,11 @@ class ProductQueryService(
             val productCategoryInfo = categoryMap[productInfo.id] ?: ProductCategoryInfo.empty()
             SearchAdminProductResponse.of(productInfo, productCategoryInfo)
         }
+    }
+
+    fun getProductDetailForAdmin(productId: Long): AdminProductDetailResponse {
+        val productInfo = productReader.getProductInfo(productId)
+        val productCategoryInfo = categoryReader.getProductCategory(productId)
+        return AdminProductDetailResponse.of(productInfo, productCategoryInfo)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/application/ProductQueryService.kt
@@ -56,4 +56,12 @@ class ProductQueryService(
         val productCategoryInfo = categoryReader.getProductCategory(productId)
         return AdminProductDetailResponse.of(productInfo, productCategoryInfo)
     }
+
+    fun getNewProducts(): List<SearchProductResponse> {
+        TODO("Not yet implemented")
+    }
+
+    fun getBestProducts(): List<SearchProductResponse> {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/model/ProductDetail.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/model/ProductDetail.kt
@@ -2,6 +2,7 @@ package com.fastcampus.commerce.product.domain.model
 
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.querydsl.core.annotations.QueryProjection
 
 data class ProductInfo
@@ -13,6 +14,7 @@ data class ProductInfo
         val quantity: Int,
         val thumbnail: String,
         val detailImage: String,
+        val status: SellingStatus,
     ) {
         companion object {
             fun of(product: Product, inventory: Inventory): ProductInfo {
@@ -23,6 +25,7 @@ data class ProductInfo
                     quantity = inventory.quantity,
                     thumbnail = product.thumbnail,
                     detailImage = product.detailImage,
+                    status = product.status,
                 )
             }
         }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/model/SearchAdminProductCondition.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/model/SearchAdminProductCondition.kt
@@ -1,0 +1,9 @@
+package com.fastcampus.commerce.product.domain.model
+
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
+
+data class SearchAdminProductCondition(
+    val name: String? = null,
+    val categories: List<Long>? = null,
+    val status: SellingStatus? = null,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/repository/ProductRepository.kt
@@ -2,6 +2,7 @@ package com.fastcampus.commerce.product.domain.repository
 
 import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.model.ProductInfo
+import com.fastcampus.commerce.product.domain.model.SearchAdminProductCondition
 import com.fastcampus.commerce.product.domain.model.SearchProductCondition
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -15,4 +16,6 @@ interface ProductRepository {
     fun delete(product: Product)
 
     fun searchProducts(condition: SearchProductCondition, pageable: Pageable): Page<ProductInfo>
+
+    fun searchProductsForAdmin(condition: SearchAdminProductCondition, pageable: Pageable): Page<ProductInfo>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductReader.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductReader.kt
@@ -5,6 +5,7 @@ import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
 import com.fastcampus.commerce.product.domain.error.ProductErrorCode
 import com.fastcampus.commerce.product.domain.model.ProductInfo
+import com.fastcampus.commerce.product.domain.model.SearchAdminProductCondition
 import com.fastcampus.commerce.product.domain.model.SearchProductCondition
 import com.fastcampus.commerce.product.domain.repository.InventoryRepository
 import com.fastcampus.commerce.product.domain.repository.ProductRepository
@@ -40,5 +41,9 @@ class ProductReader(
         val product = getProductById(productId)
         val inventory = getInventoryByProductId(productId)
         return ProductInfo.of(product, inventory)
+    }
+
+    fun searchProductsForAdmin(condition: SearchAdminProductCondition, pageable: Pageable): Page<ProductInfo> {
+        return productRepository.searchProductsForAdmin(condition, pageable)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/interfaces/ProductController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/interfaces/ProductController.kt
@@ -4,6 +4,7 @@ import com.fastcampus.commerce.common.response.PagedData
 import com.fastcampus.commerce.product.application.ProductQueryService
 import com.fastcampus.commerce.product.interfaces.request.SearchProductApiRequest
 import com.fastcampus.commerce.product.interfaces.response.CategoryApiResponse
+import com.fastcampus.commerce.product.interfaces.response.MainProductApiResponse
 import com.fastcampus.commerce.product.interfaces.response.ProductDetailApiResponse
 import com.fastcampus.commerce.product.interfaces.response.SearchProductApiResponse
 import org.springframework.data.domain.Pageable
@@ -39,5 +40,15 @@ class ProductController(
         @PathVariable productId: Long,
     ): ProductDetailApiResponse {
         return ProductDetailApiResponse.from(productQueryService.getProductDetail(productId))
+    }
+
+    @GetMapping("/main")
+    fun getMainProducts(): MainProductApiResponse {
+        val new = productQueryService.getNewProducts()
+        val best = productQueryService.getBestProducts()
+        return MainProductApiResponse(
+            new = new.map(SearchProductApiResponse::from),
+            best = best.map(SearchProductApiResponse::from),
+        )
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/interfaces/response/MainProductApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/interfaces/response/MainProductApiResponse.kt
@@ -1,0 +1,6 @@
+package com.fastcampus.commerce.product.interfaces.response
+
+data class MainProductApiResponse(
+    val new: List<SearchProductApiResponse>,
+    val best: List<SearchProductApiResponse>,
+)

--- a/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -28,6 +28,78 @@ tags:
   description: 관리자 리뷰 API
 paths:
   /admin/products:
+    get:
+      tags:
+      - Admin-Product
+      summary: 상품 목록을 조회할 수 있다.
+      operationId: 관리자_상품_목록_조회_성공
+      parameters:
+      - name: name
+        in: query
+        description: 상품명
+        required: false
+        schema:
+          type: string
+      - name: intensityId
+        in: query
+        description: 원두 강도 카테고리 ID
+        required: false
+        schema:
+          type: string
+      - name: cupSizeId
+        in: query
+        description: 컵 사이즈 카테고리 ID
+        required: false
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: "판매상태(ON_SALE, UNAVAILABLE, HIDDEN)"
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: "페이지 번호 (1부터 시작, 기본값: 1)"
+        required: false
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: Authorization
+        required: true
+        schema:
+          type: string
+        example: Bearer sample-token
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/admin-products-1101392596"
+              examples:
+                관리자_상품_목록_조회_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "content" : [ {
+                          "id" : 1,
+                          "name" : "콜드브루",
+                          "price" : 3500,
+                          "quantity" : 100,
+                          "thumbnail" : "https://test.com/thumbnail.png",
+                          "intensity" : "Strong",
+                          "cupSize" : "Large",
+                          "status" : "ON_SALE"
+                        } ],
+                        "page" : 0,
+                        "size" : 10,
+                        "totalPages" : 1,
+                        "totalElements" : 1
+                      },
+                      "error" : null
+                    }
     post:
       tags:
       - Admin-Product
@@ -205,6 +277,45 @@ paths:
                       "error" : null
                     }
   /admin/products/{productId}:
+    get:
+      tags:
+      - Admin-Product
+      summary: 상품 상세 정보를 조회할 수 있다.
+      description: |2-
+                        PRO-001: 상품을 찾을 수 없습니다.
+                        PRO-002: 상품 재고를 찾을 수 없습니다.
+      operationId: 관리자_상품_상세_조회_성공
+      parameters:
+      - name: productId
+        in: path
+        description: 상품 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/admin-products-productId-412506376"
+              examples:
+                관리자_상품_상세_조회_성공:
+                  value: |-
+                    {
+                      "data" : {
+                        "id" : 1,
+                        "name" : "콜드브루",
+                        "price" : 3500,
+                        "quantity" : 100,
+                        "thumbnail" : "https://test.com/thumbnail.png",
+                        "detailImage" : "https://test.com/detail.png",
+                        "intensity" : "Strong",
+                        "cupSize" : "Large",
+                        "status" : "ON_SALE"
+                      },
+                      "error" : null
+                    }
     put:
       tags:
       - Admin-Product
@@ -1148,13 +1259,13 @@ paths:
           type: string
       - name: page
         in: query
-        description: "페이지 번호 (0부터 시작, 기본값: 0)"
+        description: "페이지 번호 (1부터 시작, 기본값: 1)"
         required: false
         schema:
           type: string
       - name: size
         in: query
-        description: "페이지 크기 (기본값: 20, 최대: 50)"
+        description: "페이지 크기 (기본값: 10, 최대: 50)"
         required: false
         schema:
           type: string
@@ -2044,6 +2155,49 @@ components:
                   type: number
                   description: 배송지 ID
               description: 기본 배송지
+    admin-products-productId-412506376:
+      type: object
+      properties:
+        data:
+          required:
+          - cupSize
+          - detailImage
+          - id
+          - intensity
+          - name
+          - price
+          - quantity
+          - status
+          - thumbnail
+          type: object
+          properties:
+            intensity:
+              type: string
+              description: 원두 강도
+            thumbnail:
+              type: string
+              description: 썸네일 이미지 URL
+            quantity:
+              type: number
+              description: 재고 수량
+            price:
+              type: number
+              description: 가격
+            name:
+              type: string
+              description: 상품명
+            id:
+              type: number
+              description: 상품 ID
+            cupSize:
+              type: string
+              description: 컵 사이즈
+            status:
+              type: string
+              description: 판매상태
+            detailImage:
+              type: string
+              description: 상세 이미지 URL
     reviews-reviewId1686665306:
       type: object
       properties:
@@ -2821,6 +2975,67 @@ components:
             addressId:
               type: number
               description: 배송지 ID
+    admin-products-1101392596:
+      type: object
+      properties:
+        data:
+          required:
+          - page
+          - size
+          - totalElements
+          - totalPages
+          type: object
+          properties:
+            size:
+              type: number
+              description: 페이지 크기
+            totalPages:
+              type: number
+              description: 전체 페이지 수
+            page:
+              type: number
+              description: 현재 페이지 번호
+            content:
+              type: array
+              items:
+                required:
+                - cupSize
+                - id
+                - intensity
+                - name
+                - price
+                - quantity
+                - status
+                - thumbnail
+                type: object
+                properties:
+                  intensity:
+                    type: string
+                    description: 원두 강도
+                  thumbnail:
+                    type: string
+                    description: 썸네일 이미지 URL
+                  quantity:
+                    type: number
+                    description: 재고
+                  price:
+                    type: number
+                    description: 가격
+                  name:
+                    type: string
+                    description: 상품명
+                  id:
+                    type: number
+                    description: 상품 ID
+                  cupSize:
+                    type: string
+                    description: 컵 사이즈
+                  status:
+                    type: string
+                    description: 판매상태
+            totalElements:
+              type: number
+              description: 총 상품 수
     admin-products-247955186:
       required:
       - cupSizeId

--- a/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -1356,6 +1356,49 @@ paths:
                       },
                       "error" : null
                     }
+  /products/main:
+    get:
+      tags:
+      - Product
+      summary: 메인 상품 목록을 조회할 수 있다.
+      operationId: 메인_상품목록_조회
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/products-main-996164674"
+              examples:
+                메인_상품목록_조회:
+                  value: |-
+                    {
+                      "data" : {
+                        "new" : [ {
+                          "id" : 1,
+                          "name" : "콜드브루",
+                          "price" : 3500,
+                          "quantity" : 100,
+                          "thumbnail" : "https://test.com/thumbnail.png",
+                          "detailImage" : "https://test.com/detail.png",
+                          "intensity" : "Strong",
+                          "cupSize" : "Large",
+                          "isSoldOut" : false
+                        } ],
+                        "best" : [ {
+                          "id" : 1,
+                          "name" : "콜드브루",
+                          "price" : 3500,
+                          "quantity" : 100,
+                          "thumbnail" : "https://test.com/thumbnail.png",
+                          "detailImage" : "https://test.com/detail.png",
+                          "intensity" : "Strong",
+                          "cupSize" : "Large",
+                          "isSoldOut" : false
+                        } ]
+                      },
+                      "error" : null
+                    }
   /products/{productId}:
     get:
       tags:
@@ -2334,6 +2377,96 @@ components:
             key:
               type: string
               description: S3 Object Key
+    products-main-996164674:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            new:
+              type: array
+              items:
+                required:
+                - cupSize
+                - detailImage
+                - id
+                - intensity
+                - isSoldOut
+                - name
+                - price
+                - quantity
+                - thumbnail
+                type: object
+                properties:
+                  intensity:
+                    type: string
+                    description: 원두 강도
+                  thumbnail:
+                    type: string
+                    description: 썸네일 이미지 URL
+                  quantity:
+                    type: number
+                    description: 재고 수량
+                  price:
+                    type: number
+                    description: 가격
+                  isSoldOut:
+                    type: boolean
+                    description: 품절 여부
+                  name:
+                    type: string
+                    description: 상품명
+                  id:
+                    type: number
+                    description: 상품 ID
+                  cupSize:
+                    type: string
+                    description: 컵 사이즈
+                  detailImage:
+                    type: string
+                    description: 상세 이미지 URL
+            best:
+              type: array
+              items:
+                required:
+                - cupSize
+                - detailImage
+                - id
+                - intensity
+                - isSoldOut
+                - name
+                - price
+                - quantity
+                - thumbnail
+                type: object
+                properties:
+                  intensity:
+                    type: string
+                    description: 원두 강도
+                  thumbnail:
+                    type: string
+                    description: 썸네일 이미지 URL
+                  quantity:
+                    type: number
+                    description: 재고 수량
+                  price:
+                    type: number
+                    description: 가격
+                  isSoldOut:
+                    type: boolean
+                    description: 품절 여부
+                  name:
+                    type: string
+                    description: 상품명
+                  id:
+                    type: number
+                    description: 상품 ID
+                  cupSize:
+                    type: string
+                    description: 컵 사이즈
+                  detailImage:
+                    type: string
+                    description: 상세 이미지 URL
     admin-products-productId-1789436874:
       required:
       - cupSizeId

--- a/src/test/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/admin/product/application/AdminProductServiceTest.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.admin.product.application
 import com.fastcampus.commerce.admin.product.application.request.RegisterProductRequest
 import com.fastcampus.commerce.admin.product.application.request.SearchAdminProductRequest
 import com.fastcampus.commerce.admin.product.application.request.UpdateProductRequest
+import com.fastcampus.commerce.admin.product.application.response.AdminProductDetailResponse
 import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.file.application.FileCommandService
@@ -335,6 +336,77 @@ class AdminProductServiceTest : DescribeSpec(
 
                 result shouldBe expectedPage
                 verify(exactly = 1) { productQueryService.searchProductsForAdmin(statusOnlyRequest, pageable) }
+            }
+        }
+
+        describe("상품 상세 조회") {
+            val productId = 1L
+
+            it("상품 상세 정보를 조회할 수 있다.") {
+                val productInfo = ProductInfo(
+                    id = productId,
+                    name = "커피A",
+                    price = 10000,
+                    quantity = 100,
+                    thumbnail = "https://example.com/thumbnail.jpg",
+                    detailImage = "https://example.com/detailImage.jpg",
+                    status = SellingStatus.ON_SALE,
+                )
+                val productCategoryInfo = ProductCategoryInfo(
+                    intensity = "강함",
+                    cupSize = "L",
+                )
+                val expectedResponse = AdminProductDetailResponse.of(productInfo, productCategoryInfo)
+
+                every { productQueryService.getProductDetailForAdmin(productId) } returns expectedResponse
+
+                val result = service.getProduct(productId)
+
+                result shouldBe expectedResponse
+                result.id shouldBe productId
+                result.name shouldBe "커피A"
+                result.price shouldBe 10000
+                result.quantity shouldBe 100
+                result.thumbnail shouldBe "https://example.com/thumbnail.jpg"
+                result.detailImage shouldBe "https://example.com/detailImage.jpg"
+                result.intensity shouldBe "강함"
+                result.cupSize shouldBe "L"
+                result.status shouldBe SellingStatus.ON_SALE
+                verify(exactly = 1) { productQueryService.getProductDetailForAdmin(productId) }
+            }
+
+            it("상품 상세 정보에 모든 필드가 포함되어 있다.") {
+                val productInfo = ProductInfo(
+                    id = 3L,
+                    name = "프리미엄 커피",
+                    price = 25000,
+                    quantity = 50,
+                    thumbnail = "https://example.com/premium-thumbnail.jpg",
+                    detailImage = "https://example.com/premium-detail.jpg",
+                    status = SellingStatus.ON_SALE,
+                )
+                val productCategoryInfo = ProductCategoryInfo(
+                    intensity = "매우 강함",
+                    cupSize = "XL",
+                )
+                val expectedResponse = AdminProductDetailResponse.of(productInfo, productCategoryInfo)
+
+                every { productQueryService.getProductDetailForAdmin(3L) } returns expectedResponse
+
+                val result = service.getProduct(3L)
+
+                result shouldBe expectedResponse
+                // 모든 필드가 null이 아닌지 확인
+                result.id shouldBe 3L
+                result.name shouldBe "프리미엄 커피"
+                result.price shouldBe 25000
+                result.quantity shouldBe 50
+                result.thumbnail shouldBe "https://example.com/premium-thumbnail.jpg"
+                result.detailImage shouldBe "https://example.com/premium-detail.jpg"
+                result.intensity shouldBe "매우 강함"
+                result.cupSize shouldBe "XL"
+                result.status shouldBe SellingStatus.ON_SALE
+                verify(exactly = 1) { productQueryService.getProductDetailForAdmin(3L) }
             }
         }
     },

--- a/src/test/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/admin/product/interfaces/AdminProductControllerRestDocTest.kt
@@ -1,6 +1,7 @@
 package com.fastcampus.commerce.admin.product.interfaces
 
 import com.fastcampus.commerce.admin.product.application.AdminProductService
+import com.fastcampus.commerce.admin.product.application.response.AdminProductDetailResponse
 import com.fastcampus.commerce.admin.product.application.response.SearchAdminProductResponse
 import com.fastcampus.commerce.admin.product.application.response.SellingStatusResponse
 import com.fastcampus.commerce.admin.product.interfaces.request.RegisterProductApiRequest
@@ -81,11 +82,11 @@ class AdminProductControllerRestDocTest : DescribeSpec() {
                         id = 1L,
                         name = "콜드브루",
                         price = 3500,
+                        quantity = 100,
                         thumbnail = "https://test.com/thumbnail.png",
-                        status = SellingStatus.ON_SALE,
-                        stock = 100,
                         intensity = "Strong",
                         cupSize = "Large",
+                        status = SellingStatus.ON_SALE,
                     ),
                 )
                 val response = PageImpl(searchProductResponses, PageRequest.of(0, 10), 1L)
@@ -117,13 +118,64 @@ class AdminProductControllerRestDocTest : DescribeSpec() {
                         field("data.content[0].price", "가격", searchProductResponses[0].price)
                         field("data.content[0].thumbnail", "썸네일 이미지 URL", searchProductResponses[0].thumbnail)
                         field("data.content[0].status", "판매상태", searchProductResponses[0].status.name)
-                        field("data.content[0].stock", "재고", searchProductResponses[0].stock)
+                        field("data.content[0].quantity", "재고", searchProductResponses[0].quantity)
                         field("data.content[0].intensity", "원두 강도", searchProductResponses[0].intensity)
                         field("data.content[0].cupSize", "컵 사이즈", searchProductResponses[0].cupSize)
                         field("data.page", "현재 페이지 번호", response.number)
                         field("data.size", "페이지 크기", response.size)
                         field("data.totalPages", "전체 페이지 수", response.totalPages)
                         field("data.totalElements", "총 상품 수", response.totalElements.toInt())
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
+
+        describe("GET /admin/products/{productId} - 상품 상세 조회") {
+            val summary = "상품 상세 정보를 조회할 수 있다."
+            val description = """
+                PRO-001: 상품을 찾을 수 없습니다.
+                PRO-002: 상품 재고를 찾을 수 없습니다.
+            """.trimMargin()
+
+            it("상품 ID로 상품 상세 정보를 조회할 수 있다.") {
+                val productId = 1L
+                val productDetailResponse = AdminProductDetailResponse(
+                    id = productId,
+                    name = "콜드브루",
+                    price = 3500,
+                    quantity = 100,
+                    thumbnail = "https://test.com/thumbnail.png",
+                    detailImage = "https://test.com/detail.png",
+                    intensity = "Strong",
+                    cupSize = "Large",
+                    status = SellingStatus.ON_SALE,
+                )
+
+                every {
+                    adminProductService.getProduct(productId)
+                } returns productDetailResponse
+
+                documentation(
+                    identifier = "관리자_상품_상세_조회_성공",
+                    tag = tag,
+                    summary = summary,
+                    description = description,
+                ) {
+                    requestLine(HttpMethod.GET, "/admin/products/{productId}") {
+                        pathVariable("productId", "상품 ID", productId)
+                    }
+
+                    responseBody {
+                        field("data.id", "상품 ID", productDetailResponse.id.toInt())
+                        field("data.name", "상품명", productDetailResponse.name)
+                        field("data.price", "가격", productDetailResponse.price)
+                        field("data.quantity", "재고 수량", productDetailResponse.quantity)
+                        field("data.thumbnail", "썸네일 이미지 URL", productDetailResponse.thumbnail)
+                        field("data.detailImage", "상세 이미지 URL", productDetailResponse.detailImage)
+                        field("data.intensity", "원두 강도", productDetailResponse.intensity)
+                        field("data.cupSize", "컵 사이즈", productDetailResponse.cupSize)
+                        field("data.status", "판매상태", productDetailResponse.status.name)
                         ignoredField("error")
                     }
                 }

--- a/src/test/kotlin/com/fastcampus/commerce/product/application/ProductQueryServiceTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/application/ProductQueryServiceTest.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.application
 import com.fastcampus.commerce.product.application.request.SearchProductRequest
 import com.fastcampus.commerce.product.application.response.CategoryResponse
 import com.fastcampus.commerce.product.application.response.SearchProductResponse
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.model.CategoryDetail
 import com.fastcampus.commerce.product.domain.model.ProductCategoryInfo
 import com.fastcampus.commerce.product.domain.model.ProductInfo
@@ -109,6 +110,7 @@ class ProductQueryServiceTest : DescribeSpec(
                             quantity = 100,
                             thumbnail = "https://test.com/thumbnail.png",
                             detailImage = "https://test.com/detail.png",
+                            status = SellingStatus.ON_SALE,
                         ),
                         ProductInfo(
                             id = 2L,
@@ -117,6 +119,7 @@ class ProductQueryServiceTest : DescribeSpec(
                             quantity = 50,
                             thumbnail = "https://test.com/thumbnail2.png",
                             detailImage = "https://test.com/detail2.png",
+                            status = SellingStatus.ON_SALE,
                         ),
                     )
                     val productPage = PageImpl(productInfos, pageable, 2L)
@@ -173,6 +176,7 @@ class ProductQueryServiceTest : DescribeSpec(
                             quantity = 200,
                             thumbnail = "https://test.com/americano.png",
                             detailImage = "https://test.com/americano-detail.png",
+                            status = SellingStatus.ON_SALE,
                         ),
                     )
                     val productPage = PageImpl(productInfos, pageable, 1L)
@@ -216,6 +220,7 @@ class ProductQueryServiceTest : DescribeSpec(
                             quantity = 10,
                             thumbnail = "https://test.com/test.png",
                             detailImage = "https://test.com/test-detail.png",
+                            status = SellingStatus.ON_SALE,
                         ),
                     )
                     val productPage = PageImpl(productInfos, pageable, 1L)
@@ -281,6 +286,7 @@ class ProductQueryServiceTest : DescribeSpec(
                         quantity = 100,
                         thumbnail = "https://test.com/thumbnail.png",
                         detailImage = "https://test.com/detail.png",
+                        status = SellingStatus.ON_SALE,
                     )
                     val productCategoryInfo = ProductCategoryInfo(
                         intensity = "Strong",
@@ -314,6 +320,7 @@ class ProductQueryServiceTest : DescribeSpec(
                         quantity = 50,
                         thumbnail = "https://test.com/test.png",
                         detailImage = "https://test.com/test-detail.png",
+                        status = SellingStatus.ON_SALE,
                     )
                     val emptyProductCategoryInfo = ProductCategoryInfo.empty()
 

--- a/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductReaderTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/domain/service/ProductReaderTest.kt
@@ -3,6 +3,7 @@ package com.fastcampus.commerce.product.domain.service
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.product.domain.entity.Inventory
 import com.fastcampus.commerce.product.domain.entity.Product
+import com.fastcampus.commerce.product.domain.entity.SellingStatus
 import com.fastcampus.commerce.product.domain.error.ProductErrorCode
 import com.fastcampus.commerce.product.domain.model.ProductInfo
 import com.fastcampus.commerce.product.domain.model.SearchProductCondition
@@ -108,6 +109,7 @@ class ProductReaderTest : FunSpec(
                         quantity = 100,
                         thumbnail = "https://test.com/thumbnail.png",
                         detailImage = "https://test.com/detailImage.png",
+                        status = SellingStatus.ON_SALE,
                     ),
                 )
                 val expectedPage = PageImpl(expectedProductInfos, pageable, 1L)
@@ -155,6 +157,7 @@ class ProductReaderTest : FunSpec(
                     quantity = 100,
                     thumbnail = "https://test.com/thumbnail.png",
                     detailImage = "https://test.com/detailImage.png",
+                    status = SellingStatus.ON_SALE,
                 )
 
                 every { productRepository.findById(productId) } returns Optional.of(product)

--- a/src/test/kotlin/com/fastcampus/commerce/product/interfaces/ProductControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/interfaces/ProductControllerRestDocTest.kt
@@ -234,5 +234,55 @@ class ProductControllerRestDocTest : DescribeSpec() {
                 }
             }
         }
+
+        describe("GET /products/main - 메인 전시상품 조회") {
+            val summary = "메인 상품 목록을 조회할 수 있다."
+
+            it("메인 상품 목록을 조회할 수 있다.") {
+                val element = SearchProductResponse(
+                    id = 1L,
+                    name = "콜드브루",
+                    price = 3500,
+                    quantity = 100,
+                    thumbnail = "https://test.com/thumbnail.png",
+                    detailImage = "https://test.com/detail.png",
+                    intensity = "Strong",
+                    cupSize = "Large",
+                )
+
+                every { productQueryService.getNewProducts() } returns listOf(element)
+                every { productQueryService.getBestProducts() } returns listOf(element)
+
+                documentation(
+                    identifier = "메인_상품목록_조회",
+                    tag = tag,
+                    summary = summary,
+                ) {
+                    requestLine(HttpMethod.GET, "/products/main")
+
+                    responseBody {
+                        field("data.new[0].id", "상품 ID", element.id.toInt())
+                        field("data.new[0].name", "상품명", element.name)
+                        field("data.new[0].price", "가격", element.price)
+                        field("data.new[0].quantity", "재고 수량", element.quantity)
+                        field("data.new[0].thumbnail", "썸네일 이미지 URL", element.thumbnail)
+                        field("data.new[0].detailImage", "상세 이미지 URL", element.detailImage)
+                        field("data.new[0].intensity", "원두 강도", element.intensity)
+                        field("data.new[0].cupSize", "컵 사이즈", element.cupSize)
+                        field("data.new[0].isSoldOut", "품절 여부", false)
+                        field("data.best[0].id", "상품 ID", element.id.toInt())
+                        field("data.best[0].name", "상품명", element.name)
+                        field("data.best[0].price", "가격", element.price)
+                        field("data.best[0].quantity", "재고 수량", element.quantity)
+                        field("data.best[0].thumbnail", "썸네일 이미지 URL", element.thumbnail)
+                        field("data.best[0].detailImage", "상세 이미지 URL", element.detailImage)
+                        field("data.best[0].intensity", "원두 강도", element.intensity)
+                        field("data.best[0].cupSize", "컵 사이즈", element.cupSize)
+                        field("data.best[0].isSoldOut", "품절 여부", false)
+                        ignoredField("error")
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/fastcampus/commerce/product/interfaces/ProductControllerRestDocTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/product/interfaces/ProductControllerRestDocTest.kt
@@ -133,8 +133,8 @@ class ProductControllerRestDocTest : DescribeSpec() {
                         optionalField("name", "상품명 (부분 검색)", "콜드브루")
                         optionalField("intensityId", "원두 강도 카테고리 ID", 1)
                         optionalField("cupSizeId", "컵 사이즈 카테고리 ID", 2)
-                        optionalField("page", "페이지 번호 (0부터 시작, 기본값: 0)", 0)
-                        optionalField("size", "페이지 크기 (기본값: 20, 최대: 50)", 20)
+                        optionalField("page", "페이지 번호 (1부터 시작, 기본값: 1)", 1)
+                        optionalField("size", "페이지 크기 (기본값: 10, 최대: 50)", 10)
                     }
 
                     responseBody {


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #54 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->