### PR TITLE
[feat] 주문 취소 API 추가

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/order/application/order/OrderService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/application/order/OrderService.kt
@@ -256,7 +256,7 @@ class OrderService(
         )
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     fun cancelOrder(orderNumber: String) {
         val order = orderRepository.findByOrderNumber(orderNumber)
             ?: throw CoreException(OrderErrorCode.ORDER_NOT_FOUND)

--- a/src/main/kotlin/com/fastcampus/commerce/order/application/order/OrderService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/application/order/OrderService.kt
@@ -4,6 +4,7 @@ import com.fastcampus.commerce.cart.application.query.CartItemReader
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.common.response.EnumResponse
 import com.fastcampus.commerce.common.response.PagedData
+import com.fastcampus.commerce.common.util.TimeProvider
 import com.fastcampus.commerce.order.application.query.ProductSnapshotReader
 import com.fastcampus.commerce.order.domain.entity.Order
 import com.fastcampus.commerce.order.domain.entity.OrderItem
@@ -27,6 +28,7 @@ import com.fastcampus.commerce.payment.domain.service.PaymentReader
 import com.fastcampus.commerce.review.domain.repository.ReviewRepository
 import com.fastcampus.commerce.user.api.service.UserAddressService
 import com.fastcampus.commerce.user.domain.entity.User
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -42,6 +44,7 @@ class OrderService(
     private val userAddressService: UserAddressService,
     private val paymentReader: PaymentReader,
     private val reviewRepository: ReviewRepository,
+    private val timeProvider: TimeProvider,
 ) {
 
     // 배송비 정책 (정책에 따라 변경 예정)
@@ -150,7 +153,7 @@ class OrderService(
     fun getOrders(
         request: SearchOrderApiRequest,
         pageable: Pageable
-    ): PagedData<SearchOrderApiResponse> {
+    ): Page<SearchOrderApiResponse> {
         // 1. 조건에 맞는 주문 페이지 조회 (ex: 유저ID 기준)
         val page = orderRepository.findAllByUserId(
             userId = request.customerId!!.toLong(),
@@ -177,7 +180,7 @@ class OrderService(
             )
         }
 
-        return PagedData.of(PageImpl(responses, pageable, page.totalElements))
+        return PageImpl(responses, pageable, page.totalElements)
     }
 
     @Transactional(readOnly = true)
@@ -253,4 +256,11 @@ class OrderService(
         )
     }
 
+    @Transactional(readOnly = true)
+    fun cancelOrder(orderNumber: String) {
+        val order = orderRepository.findByOrderNumber(orderNumber)
+            ?: throw CoreException(OrderErrorCode.ORDER_NOT_FOUND)
+        val cancelledAt = timeProvider.now()
+        order.cancel(cancelledAt)
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/order/interfaces/OrderController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/interfaces/OrderController.kt
@@ -5,6 +5,7 @@ import com.fastcampus.commerce.common.response.PagedData
 import com.fastcampus.commerce.order.application.order.OrderService
 import com.fastcampus.commerce.order.interfaces.request.OrderApiRequest
 import com.fastcampus.commerce.order.interfaces.request.SearchOrderApiRequest
+import com.fastcampus.commerce.order.interfaces.response.CancelOrderApiResponse
 import com.fastcampus.commerce.order.interfaces.response.GetOrderApiResponse
 import com.fastcampus.commerce.order.interfaces.response.GetOrderItemApiResponse
 import com.fastcampus.commerce.order.interfaces.response.GetOrderShippingInfoApiResponse
@@ -17,6 +18,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
@@ -107,7 +109,7 @@ class OrderController(
         @ModelAttribute request: SearchOrderApiRequest,
         @PageableDefault(page = 1, size = 10) pageable: Pageable,
     ): PagedData<SearchOrderApiResponse> {
-        return orderService.getOrders(request, pageable)
+        return PagedData.of(orderService.getOrders(request, pageable))
     }
 
     /*@GetMapping("/{orderNumber}")
@@ -163,5 +165,13 @@ class OrderController(
         @PathVariable orderNumber: String,
     ): GetOrderApiResponse {
         return orderService.getOrderDetail(orderNumber)
+    }
+
+    @PostMapping("/{orderNumber}/cancel")
+    fun cancelOrder(
+        @PathVariable orderNumber: String,
+    ): CancelOrderApiResponse {
+        orderService.cancelOrder(orderNumber)
+       return CancelOrderApiResponse()
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/order/interfaces/response/CancelOrderApiResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/interfaces/response/CancelOrderApiResponse.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.order.interfaces.response
+
+data class CancelOrderApiResponse (
+    val message: String = "OK",
+)

--- a/src/main/resources/config/db.yml
+++ b/src/main/resources/config/db.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       default_batch_fetch_size: 100
 
@@ -12,7 +12,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
@@ -23,7 +23,7 @@ spring:
     baseline-on-migrate: false
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: commerce
-    password: aa
+    url: jdbc:postgresql://postgresql-801base-1.c96ycouowc7e.ap-northeast-2.rds.amazonaws.com:5432/commerce
+    username: db801base
+    password: 801baseWkdWkd
 

--- a/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -80,26 +80,14 @@ paths:
                 $ref: "#/components/schemas/admin-products-1101392596"
               examples:
                 관리자_상품_목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ {
-                          "id" : 1,
-                          "name" : "콜드브루",
-                          "price" : 3500,
-                          "quantity" : 100,
-                          "thumbnail" : "https://test.com/thumbnail.png",
-                          "intensity" : "Strong",
-                          "cupSize" : "Large",
-                          "status" : "ON_SALE"
-                        } ],
-                        "page" : 0,
-                        "size" : 10,
-                        "totalPages" : 1,
-                        "totalElements" : 1
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
+                    id\" : 1,\r\n      \"name\" : \"콜드브루\",\r\n      \"price\" : 3500,\r\
+                    \n      \"quantity\" : 100,\r\n      \"thumbnail\" : \"https://test.com/thumbnail.png\"\
+                    ,\r\n      \"intensity\" : \"Strong\",\r\n      \"cupSize\" :\
+                    \ \"Large\",\r\n      \"status\" : \"ON_SALE\"\r\n    } ],\r\n\
+                    \    \"page\" : 0,\r\n    \"size\" : 10,\r\n    \"totalPages\"\
+                    \ : 1,\r\n    \"totalElements\" : 1\r\n  },\r\n  \"error\" : null\r\
+                    \n}"
     post:
       tags:
       - Admin-Product
@@ -126,16 +114,10 @@ paths:
               $ref: "#/components/schemas/admin-products-247955186"
             examples:
               상품_등록_성공:
-                value: |-
-                  {
-                    "name" : "콜드브루",
-                    "price" : 3500,
-                    "quantity" : 100,
-                    "thumbnail" : "https://test.com/thumbnail.png",
-                    "detailImage" : "https://test.com/detailImage.png",
-                    "intensityId" : 1,
-                    "cupSizeId" : 10
-                  }
+                value: "{\r\n  \"name\" : \"콜드브루\",\r\n  \"price\" : 3500,\r\n  \"\
+                  quantity\" : 100,\r\n  \"thumbnail\" : \"https://test.com/thumbnail.png\"\
+                  ,\r\n  \"detailImage\" : \"https://test.com/detailImage.png\",\r\
+                  \n  \"intensityId\" : 1,\r\n  \"cupSizeId\" : 10\r\n}"
       responses:
         "200":
           description: "200"
@@ -145,13 +127,8 @@ paths:
                 $ref: "#/components/schemas/admin-products9820101"
               examples:
                 상품_등록_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "productId" : 10
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"productId\" : 10\r\n  },\r\n\
+                    \  \"error\" : null\r\n}"
   /admin/reviews:
     get:
       tags:
@@ -217,34 +194,17 @@ paths:
                 $ref: "#/components/schemas/admin-reviews1949273614"
               examples:
                 관리자_리뷰목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ {
-                          "reviewId" : 10,
-                          "rating" : 5,
-                          "content" : "좋아요.",
-                          "adminReply" : {
-                            "content" : "감사합니다.",
-                            "createdAt" : "2025-06-12T12:00"
-                          },
-                          "user" : {
-                            "userId" : 1,
-                            "nickname" : "커피좋아"
-                          },
-                          "product" : {
-                            "productId" : 1,
-                            "productName" : "스타벅스 캡슐커피"
-                          },
-                          "createdAt" : "2025-06-12T12:00"
-                        } ],
-                        "page" : 1,
-                        "size" : 10,
-                        "totalPages" : 2,
-                        "totalElements" : 11
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
+                    reviewId\" : 10,\r\n      \"rating\" : 5,\r\n      \"content\"\
+                    \ : \"좋아요.\",\r\n      \"adminReply\" : {\r\n        \"content\"\
+                    \ : \"감사합니다.\",\r\n        \"createdAt\" : \"2025-06-12T12:00\"\
+                    \r\n      },\r\n      \"user\" : {\r\n        \"userId\" : 1,\r\
+                    \n        \"nickname\" : \"커피좋아\"\r\n      },\r\n      \"product\"\
+                    \ : {\r\n        \"productId\" : 1,\r\n        \"productName\"\
+                    \ : \"스타벅스 캡슐커피\"\r\n      },\r\n      \"createdAt\" : \"2025-06-12T12:00\"\
+                    \r\n    } ],\r\n    \"page\" : 1,\r\n    \"size\" : 10,\r\n  \
+                    \  \"totalPages\" : 2,\r\n    \"totalElements\" : 11\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /admin/products/selling-status:
     get:
       tags:
@@ -268,14 +228,8 @@ paths:
                 $ref: "#/components/schemas/admin-products-selling-status-152159338"
               examples:
                 상품_판매상태_조회_성공:
-                  value: |-
-                    {
-                      "data" : [ {
-                        "code" : "ON_SALE",
-                        "label" : "판매중"
-                      } ],
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : [ {\r\n    \"code\" : \"ON_SALE\",\r\n\
+                    \    \"label\" : \"판매중\"\r\n  } ],\r\n  \"error\" : null\r\n}"
   /admin/products/{productId}:
     get:
       tags:
@@ -301,21 +255,13 @@ paths:
                 $ref: "#/components/schemas/admin-products-productId-412506376"
               examples:
                 관리자_상품_상세_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "id" : 1,
-                        "name" : "콜드브루",
-                        "price" : 3500,
-                        "quantity" : 100,
-                        "thumbnail" : "https://test.com/thumbnail.png",
-                        "detailImage" : "https://test.com/detail.png",
-                        "intensity" : "Strong",
-                        "cupSize" : "Large",
-                        "status" : "ON_SALE"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"id\" : 1,\r\n    \"name\" :\
+                    \ \"콜드브루\",\r\n    \"price\" : 3500,\r\n    \"quantity\" : 100,\r\
+                    \n    \"thumbnail\" : \"https://test.com/thumbnail.png\",\r\n\
+                    \    \"detailImage\" : \"https://test.com/detail.png\",\r\n  \
+                    \  \"intensity\" : \"Strong\",\r\n    \"cupSize\" : \"Large\"\
+                    ,\r\n    \"status\" : \"ON_SALE\"\r\n  },\r\n  \"error\" : null\r\
+                    \n}"
     put:
       tags:
       - Admin-Product
@@ -350,17 +296,11 @@ paths:
               $ref: "#/components/schemas/admin-products-productId-1789436874"
             examples:
               상품_수정_성공:
-                value: |-
-                  {
-                    "name" : "콜드브루",
-                    "price" : 3500,
-                    "quantity" : 100,
-                    "thumbnail" : "https://test.com/thumbnail.png",
-                    "detailImage" : "https://test.com/detailImage.png",
-                    "intensityId" : 1,
-                    "cupSizeId" : 10,
-                    "status" : "UNAVAILABLE"
-                  }
+                value: "{\r\n  \"name\" : \"콜드브루\",\r\n  \"price\" : 3500,\r\n  \"\
+                  quantity\" : 100,\r\n  \"thumbnail\" : \"https://test.com/thumbnail.png\"\
+                  ,\r\n  \"detailImage\" : \"https://test.com/detailImage.png\",\r\
+                  \n  \"intensityId\" : 1,\r\n  \"cupSizeId\" : 10,\r\n  \"status\"\
+                  \ : \"UNAVAILABLE\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -370,13 +310,8 @@ paths:
                 $ref: "#/components/schemas/admin-products-productId-1712578160"
               examples:
                 상품_수정_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "productId" : 10
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"productId\" : 10\r\n  },\r\n\
+                    \  \"error\" : null\r\n}"
     delete:
       tags:
       - Admin-Product
@@ -405,16 +340,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 상품_삭제_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /admin/payments/refund/approve:
     post:
       tags:
@@ -440,26 +370,18 @@ paths:
               $ref: "#/components/schemas/admin-payments-refund-reject-1038851161"
             examples:
               관리자_환불승인_성공:
-                value: |-
-                  {
-                    "paymentNumber" : "PAY00001"
-                  }
+                value: "{\r\n  \"paymentNumber\" : \"PAY00001\"\r\n}"
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 관리자_환불승인_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /admin/payments/refund/reject:
     post:
       tags:
@@ -485,26 +407,18 @@ paths:
               $ref: "#/components/schemas/admin-payments-refund-reject-1038851161"
             examples:
               관리자_환불거절_성공:
-                value: |-
-                  {
-                    "paymentNumber" : "PAY00001"
-                  }
+                value: "{\r\n  \"paymentNumber\" : \"PAY00001\"\r\n}"
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 관리자_환불거절_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /admin/reviews/reply/{replyId}:
     put:
       tags:
@@ -535,10 +449,7 @@ paths:
               $ref: "#/components/schemas/admin-reviews-reply-replyId800783421"
             examples:
               관리자_리뷰답글_수정_성공:
-                value: |-
-                  {
-                    "content" : "감사합니다."
-                  }
+                value: "{\r\n  \"content\" : \"감사합니다.\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -548,13 +459,8 @@ paths:
                 $ref: "#/components/schemas/admin-reviews-reply-replyId1254049025"
               examples:
                 관리자_리뷰답글_수정_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "replyId" : 1
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"replyId\" : 1\r\n  },\r\n \
+                    \ \"error\" : null\r\n}"
     delete:
       tags:
       - Admin-Review
@@ -581,16 +487,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 관리자_리뷰답글_삭제_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /admin/reviews/{reviewId}/reply:
     post:
       tags:
@@ -621,10 +522,7 @@ paths:
               $ref: "#/components/schemas/admin-reviews-reply-replyId800783421"
             examples:
               관리자_리뷰답글_등록_성공:
-                value: |-
-                  {
-                    "content" : "감사합니다."
-                  }
+                value: "{\r\n  \"content\" : \"감사합니다.\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -634,13 +532,8 @@ paths:
                 $ref: "#/components/schemas/admin-reviews-reply-replyId1254049025"
               examples:
                 관리자_리뷰답글_등록_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "replyId" : 1
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"replyId\" : 1\r\n  },\r\n \
+                    \ \"error\" : null\r\n}"
   /cart-items:
     get:
       tags:
@@ -664,33 +557,18 @@ paths:
                 $ref: "#/components/schemas/cart-items-761185737"
               examples:
                 장바구니_상품_목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "totalPrice" : 80000,
-                        "deliveryPrice" : 0,
-                        "cartItems" : [ {
-                          "cartItemId" : 101,
-                          "productId" : 1,
-                          "productName" : "Product 1",
-                          "quantity" : 2,
-                          "price" : 10000,
-                          "stockQuantity" : 10,
-                          "thumbnail" : "thumbnail1.jpg",
-                          "isAvailable" : true
-                        }, {
-                          "cartItemId" : 102,
-                          "productId" : 2,
-                          "productName" : "Product 2",
-                          "quantity" : 3,
-                          "price" : 20000,
-                          "stockQuantity" : 5,
-                          "thumbnail" : "thumbnail2.jpg",
-                          "isAvailable" : true
-                        } ]
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"totalPrice\" : 80000,\r\n \
+                    \   \"deliveryPrice\" : 0,\r\n    \"cartItems\" : [ {\r\n    \
+                    \  \"cartItemId\" : 101,\r\n      \"productId\" : 1,\r\n     \
+                    \ \"productName\" : \"Product 1\",\r\n      \"quantity\" : 2,\r\
+                    \n      \"price\" : 10000,\r\n      \"stockQuantity\" : 10,\r\n\
+                    \      \"thumbnail\" : \"thumbnail1.jpg\",\r\n      \"isAvailable\"\
+                    \ : true\r\n    }, {\r\n      \"cartItemId\" : 102,\r\n      \"\
+                    productId\" : 2,\r\n      \"productName\" : \"Product 2\",\r\n\
+                    \      \"quantity\" : 3,\r\n      \"price\" : 20000,\r\n     \
+                    \ \"stockQuantity\" : 5,\r\n      \"thumbnail\" : \"thumbnail2.jpg\"\
+                    ,\r\n      \"isAvailable\" : true\r\n    } ]\r\n  },\r\n  \"error\"\
+                    \ : null\r\n}"
     post:
       tags:
       - Cart
@@ -711,11 +589,7 @@ paths:
               $ref: "#/components/schemas/cart-items1349440338"
             examples:
               장바구니에_상품_추가_성공:
-                value: |-
-                  {
-                    "productId" : 1,
-                    "quantity" : 100
-                  }
+                value: "{\r\n  \"productId\" : 1,\r\n  \"quantity\" : 100\r\n}"
       responses:
         "200":
           description: "200"
@@ -725,15 +599,9 @@ paths:
                 $ref: "#/components/schemas/cart-items151658045"
               examples:
                 장바구니에_상품_추가_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "quantity" : 80,
-                        "stockQuantity" : 80,
-                        "requiresQuantityAdjustment" : true
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"quantity\" : 80,\r\n    \"\
+                    stockQuantity\" : 80,\r\n    \"requiresQuantityAdjustment\" :\
+                    \ true\r\n  },\r\n  \"error\" : null\r\n}"
     delete:
       tags:
       - Cart
@@ -752,16 +620,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 장바구니_상품_삭제_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "Successfully deleted 1 cart items"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"Successfully\
+                    \ deleted 1 cart items\"\r\n  },\r\n  \"error\" : null\r\n}"
   /cart-items/{cartItemId}:
     patch:
       tags:
@@ -789,11 +652,7 @@ paths:
               $ref: "#/components/schemas/cart-items-cartItemId-2049702389"
             examples:
               장바구니_상품_수정_성공:
-                value: |-
-                  {
-                    "cartItemId" : 1,
-                    "quantity" : 100
-                  }
+                value: "{\r\n  \"cartItemId\" : 1,\r\n  \"quantity\" : 100\r\n}"
       responses:
         "200":
           description: "200"
@@ -803,17 +662,10 @@ paths:
                 $ref: "#/components/schemas/cart-items-cartItemId838557620"
               examples:
                 장바구니_상품_수정_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "userId" : 1,
-                        "productId" : 1,
-                        "quantity" : 80,
-                        "stockQuantity" : 80,
-                        "requiresQuantityAdjustment" : true
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"userId\" : 1,\r\n    \"productId\"\
+                    \ : 1,\r\n    \"quantity\" : 80,\r\n    \"stockQuantity\" : 80,\r\
+                    \n    \"requiresQuantityAdjustment\" : true\r\n  },\r\n  \"error\"\
+                    \ : null\r\n}"
   /files/presigned-url:
     post:
       tags:
@@ -835,15 +687,10 @@ paths:
               $ref: "#/components/schemas/files-presigned-url-1375438577"
             examples:
               PresignedURL_발급_성공:
-                value: |-
-                  {
-                    "fileName" : "사진입니다.jpg",
-                    "contentType" : "image/jpeg",
-                    "fileSize" : 1048576,
-                    "domainType" : "PRODUCT",
-                    "domainContext" : "thumbnail",
-                    "contextId" : "6d851850-3b6f-4230-97fe-1a55b44fc862"
-                  }
+                value: "{\r\n  \"fileName\" : \"사진입니다.jpg\",\r\n  \"contentType\"\
+                  \ : \"image/jpeg\",\r\n  \"fileSize\" : 1048576,\r\n  \"domainType\"\
+                  \ : \"PRODUCT\",\r\n  \"domainContext\" : \"thumbnail\",\r\n  \"\
+                  contextId\" : \"6d851850-3b6f-4230-97fe-1a55b44fc862\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -853,15 +700,10 @@ paths:
                 $ref: "#/components/schemas/files-presigned-url-2064193514"
               examples:
                 PresignedURL_발급_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "uploadUrl" : "https://test-801base-bucket.com/product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg",
-                        "key" : "product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg",
-                        "contextId" : "6d851850-3b6f-4230-97fe-1a55b44fc862"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"uploadUrl\" : \"https://test-801base-bucket.com/product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg\"\
+                    ,\r\n    \"key\" : \"product/6d851850-3b6f-4230-97fe-1a55b44fc862/thumbnail-uuid.jpg\"\
+                    ,\r\n    \"contextId\" : \"6d851850-3b6f-4230-97fe-1a55b44fc862\"\
+                    \r\n  },\r\n  \"error\" : null\r\n}"
   /orders:
     get:
       tags:
@@ -891,26 +733,15 @@ paths:
                 $ref: "#/components/schemas/orders-2108059589"
               examples:
                 주문_목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ {
-                          "orderNumber" : "ORD20250609123456789",
-                          "orderName" : "스페셜 리버즈 외 3건",
-                          "mainProductThumbnail" : "https://example.com/thumbnail.jpg",
-                          "orderStatus" : "배송 준비중",
-                          "finalTotalPrice" : 13000,
-                          "orderedAt" : "2025-06-08T12:34",
-                          "cancellable" : true,
-                          "refundable" : false
-                        } ],
-                        "page" : 1,
-                        "size" : 10,
-                        "totalPages" : 2,
-                        "totalElements" : 11
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
+                    orderNumber\" : \"ORD20250609123456789\",\r\n      \"orderName\"\
+                    \ : \"스페셜 리버즈 외 3건\",\r\n      \"mainProductThumbnail\" : \"https://example.com/thumbnail.jpg\"\
+                    ,\r\n      \"orderStatus\" : \"DELIVERED\",\r\n      \"finalTotalPrice\"\
+                    \ : 13000,\r\n      \"orderedAt\" : \"2025-06-08T12:34\",\r\n\
+                    \      \"cancellable\" : true,\r\n      \"refundable\" : false\r\
+                    \n    } ],\r\n    \"page\" : 1,\r\n    \"size\" : 10,\r\n    \"\
+                    totalPages\" : 2,\r\n    \"totalElements\" : 11\r\n  },\r\n  \"\
+                    error\" : null\r\n}"
     post:
       tags:
       - Order
@@ -931,19 +762,12 @@ paths:
               $ref: "#/components/schemas/orders-1934294331"
             examples:
               주문_생성_성공:
-                value: |-
-                  {
-                    "cartItemIds" : [ 1, 2, 3 ],
-                    "shippingInfo" : {
-                      "recipientName" : "홍길동",
-                      "recipientPhone" : "010-1234-1234",
-                      "zipCode" : "12345",
-                      "address1" : "서울특별시 관악구",
-                      "address2" : "서울대입구역 6번출구",
-                      "deliveryMessage" : "문앞에 놔주세요"
-                    },
-                    "paymentMethod" : "TOSS_PAY"
-                  }
+                value: "{\r\n  \"cartItemIds\" : [ 1, 2, 3 ],\r\n  \"shippingInfo\"\
+                  \ : {\r\n    \"recipientName\" : \"홍길동\",\r\n    \"recipientPhone\"\
+                  \ : \"010-1234-1234\",\r\n    \"zipCode\" : \"12345\",\r\n    \"\
+                  address1\" : \"서울특별시 관악구\",\r\n    \"address2\" : \"서울대입구역 6번출구\"\
+                  ,\r\n    \"deliveryMessage\" : \"문앞에 놔주세요\"\r\n  },\r\n  \"paymentMethod\"\
+                  \ : \"TOSS_PAY\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -953,13 +777,8 @@ paths:
                 $ref: "#/components/schemas/orders-841088526"
               examples:
                 주문_생성_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "orderNumber" : "ORD20250609123456789"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"orderNumber\" : \"ORD20250609123456789\"\
+                    \r\n  },\r\n  \"error\" : null\r\n}"
   /orders/prepare:
     get:
       tags:
@@ -986,38 +805,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/orders-prepare-1188466473"
+                $ref: "#/components/schemas/orders-prepare1135603467"
               examples:
                 주문서_생성_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "cartItemIds" : [ 1 ],
-                        "itemsSubtotal" : 10000,
-                        "shippingFee" : 3000,
-                        "finalTotalPrice" : 13000,
-                        "items" : [ {
-                          "productId" : 1,
-                          "name" : "상품A",
-                          "thumbnail" : "http://localhost:8080/api/v1/product/1/thumbnail",
-                          "unitPrice" : 1000,
-                          "quantity" : 10,
-                          "itemSubtotal" : 10000
-                        } ],
-                        "shippingInfo" : {
-                          "recipientName" : "홍길동",
-                          "recipientPhone" : "010-1234-1234",
-                          "zipCode" : "12345",
-                          "address1" : "서울특별시 관악구",
-                          "address2" : "서울대입구역 6번출구"
-                        },
-                        "paymentMethod" : [ {
-                          "code" : "MOCK",
-                          "label" : "테스트"
-                        } ]
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"cartItemIds\" : [ 1 ],\r\n\
+                    \    \"itemsSubtotal\" : 10000,\r\n    \"shippingFee\" : 3000,\r\
+                    \n    \"finalTotalPrice\" : 13000,\r\n    \"items\" : [ {\r\n\
+                    \      \"productId\" : 1,\r\n      \"name\" : \"상품A\",\r\n   \
+                    \   \"thumbnail\" : \"http://localhost:8080/api/v1/product/1/thumbnail\"\
+                    ,\r\n      \"unitPrice\" : 1000,\r\n      \"quantity\" : 10,\r\
+                    \n      \"itemSubtotal\" : 10000\r\n    } ],\r\n    \"shippingInfo\"\
+                    \ : {\r\n      \"recipientName\" : \"홍길동\",\r\n      \"recipientPhone\"\
+                    \ : \"010-1234-1234\",\r\n      \"zipCode\" : \"12345\",\r\n \
+                    \     \"addressId\" : 1,\r\n      \"address1\" : \"서울특별시 관악구\"\
+                    ,\r\n      \"address2\" : \"서울대입구역 6번출구\"\r\n    },\r\n    \"\
+                    paymentMethod\" : [ {\r\n      \"code\" : \"MOCK\",\r\n      \"\
+                    label\" : \"테스트\"\r\n    } ]\r\n  },\r\n  \"error\" : null\r\n\
+                    }"
   /orders/{orderNumber}:
     get:
       tags:
@@ -1047,49 +851,67 @@ paths:
                 $ref: "#/components/schemas/orders-orderNumber1806927897"
               examples:
                 주문_상세_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "orderNumber" : "ORD20250609123456789",
-                        "orderName" : "홍길동님의 주문",
-                        "orderStatus" : "배송 준비중",
-                        "paymentNumber" : "PAY1231414124",
-                        "paymentMethod" : "토스페이",
-                        "itemsSubTotal" : 10000,
-                        "shippingFee" : 3000,
-                        "finalTotalPrice" : 13000,
-                        "items" : [ {
-                          "orderItemId" : 1,
-                          "productSnapshotId" : 1,
-                          "name" : "상품명",
-                          "thumbnail" : "https://example.com/thumbnail.jpg",
-                          "unitPrice" : 1000,
-                          "quantity" : 10,
-                          "itemSubTotal" : 10000
-                        } ],
-                        "shippingInfo" : {
-                          "recipientName" : "홍길동",
-                          "recipientPhone" : "010-1234-1234",
-                          "zipCode" : "08123",
-                          "address1" : "서울특별시 관악구",
-                          "address2" : "1000003동 123호",
-                          "deliveryMessage" : "문앞에 놔주세요."
-                        },
-                        "orderedAt" : "2025-06-08T12:34",
-                        "paidAt" : "2025-06-08T12:34",
-                        "cancellable" : true,
-                        "cancelRequested" : false,
-                        "cancelledAt" : null,
-                        "refundable" : false,
-                        "refundRequested" : false,
-                        "refundRequestedAt" : null,
-                        "refunded" : false,
-                        "refundedAt" : null,
-                        "reviewable" : true,
-                        "reviewWritten" : false
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"orderNumber\" : \"ORD20250609123456789\"\
+                    ,\r\n    \"orderName\" : \"홍길동님의 주문\",\r\n    \"orderStatus\"\
+                    \ : \"배송 준비중\",\r\n    \"paymentNumber\" : \"PAY1231414124\",\r\
+                    \n    \"paymentMethod\" : \"토스페이\",\r\n    \"itemsSubTotal\" :\
+                    \ 10000,\r\n    \"shippingFee\" : 3000,\r\n    \"finalTotalPrice\"\
+                    \ : 13000,\r\n    \"items\" : [ {\r\n      \"orderItemId\" : 1,\r\
+                    \n      \"productSnapshotId\" : 1,\r\n      \"name\" : \"상품명\"\
+                    ,\r\n      \"thumbnail\" : \"https://example.com/thumbnail.jpg\"\
+                    ,\r\n      \"unitPrice\" : 1000,\r\n      \"quantity\" : 10,\r\
+                    \n      \"itemSubTotal\" : 10000\r\n    } ],\r\n    \"shippingInfo\"\
+                    \ : {\r\n      \"recipientName\" : \"홍길동\",\r\n      \"recipientPhone\"\
+                    \ : \"010-1234-1234\",\r\n      \"zipCode\" : \"08123\",\r\n \
+                    \     \"address1\" : \"서울특별시 관악구\",\r\n      \"address2\" : \"\
+                    1000003동 123호\",\r\n      \"deliveryMessage\" : \"문앞에 놔주세요.\"\r\
+                    \n    },\r\n    \"orderedAt\" : \"2025-06-08T12:34\",\r\n    \"\
+                    paidAt\" : \"2025-06-08T12:34\",\r\n    \"cancellable\" : true,\r\
+                    \n    \"cancelRequested\" : false,\r\n    \"cancelledAt\" : null,\r\
+                    \n    \"refundable\" : false,\r\n    \"refundRequested\" : false,\r\
+                    \n    \"refundRequestedAt\" : null,\r\n    \"refunded\" : false,\r\
+                    \n    \"refundedAt\" : null,\r\n    \"reviewable\" : true,\r\n\
+                    \    \"reviewWritten\" : false\r\n  },\r\n  \"error\" : null\r\
+                    \n}"
+  /orders/{orderNumber}/cancel:
+    post:
+      tags:
+      - Order
+      summary: 주문을 취소합니다
+      operationId: 주문_취소_성공
+      parameters:
+      - name: orderNumber
+        in: path
+        description: 주문 번호
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: 인증 토큰
+        required: true
+        schema:
+          type: string
+        example: Bearer sample-token
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/orders-orderNumber-cancel486549215"
+            examples:
+              주문_취소_성공:
+                value: "{ }"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/payments-cancel1686665306"
+              examples:
+                주문_취소_성공:
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /payments:
     post:
       tags:
@@ -1118,11 +940,8 @@ paths:
               $ref: "#/components/schemas/payments808279509"
             examples:
               결제처리_성공:
-                value: |-
-                  {
-                    "orderNumber" : "ORD123123123",
-                    "transactionId" : "12312312-123"
-                  }
+                value: "{\r\n  \"orderNumber\" : \"ORD123123123\",\r\n  \"transactionId\"\
+                  \ : \"12312312-123\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -1132,13 +951,8 @@ paths:
                 $ref: "#/components/schemas/payments-2018243494"
               examples:
                 결제처리_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "paymentNumber" : "PAY00001"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"paymentNumber\" : \"PAY00001\"\
+                    \r\n  },\r\n  \"error\" : null\r\n}"
   /payments/cancel:
     post:
       tags:
@@ -1164,29 +978,21 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: "#/components/schemas/payments-refund-919447853"
+              $ref: "#/components/schemas/payments-cancel-919447853"
             examples:
               결제취소_성공:
-                value: |-
-                  {
-                    "orderNumber" : "ORD123123123"
-                  }
+                value: "{\r\n  \"orderNumber\" : \"ORD123123123\"\r\n}"
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 결제취소_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /payments/refund:
     post:
       tags:
@@ -1209,29 +1015,21 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: "#/components/schemas/payments-refund-919447853"
+              $ref: "#/components/schemas/payments-cancel-919447853"
             examples:
               결제환불요청_성공:
-                value: |-
-                  {
-                    "orderNumber" : "ORD123123123"
-                  }
+                value: "{\r\n  \"orderNumber\" : \"ORD123123123\"\r\n}"
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 결제환불요청_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /products:
     get:
       tags:
@@ -1241,8 +1039,8 @@ paths:
       parameters:
       - name: name
         in: query
-        description: 상품명 (부분 검색)
-        required: false
+        description: 존재하지 않는 상품명
+        required: true
         schema:
           type: string
       - name: intensityId
@@ -1277,50 +1075,25 @@ paths:
               schema:
                 $ref: "#/components/schemas/products-1886796052"
               examples:
-                상품_목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ {
-                          "id" : 1,
-                          "name" : "콜드브루",
-                          "price" : 3500,
-                          "quantity" : 100,
-                          "thumbnail" : "https://test.com/thumbnail.png",
-                          "detailImage" : "https://test.com/detail.png",
-                          "intensity" : "Strong",
-                          "cupSize" : "Large",
-                          "isSoldOut" : false
-                        }, {
-                          "id" : 2,
-                          "name" : "아메리카노",
-                          "price" : 3000,
-                          "quantity" : 150,
-                          "thumbnail" : "https://test.com/americano.png",
-                          "detailImage" : "https://test.com/americano-detail.png",
-                          "intensity" : "Medium",
-                          "cupSize" : "Small",
-                          "isSoldOut" : false
-                        } ],
-                        "page" : 0,
-                        "size" : 20,
-                        "totalPages" : 1,
-                        "totalElements" : 2
-                      },
-                      "error" : null
-                    }
                 상품_검색_결과_없음:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ ],
-                        "page" : 0,
-                        "size" : 20,
-                        "totalPages" : 0,
-                        "totalElements" : 0
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ ],\r\n    \"\
+                    page\" : 0,\r\n    \"size\" : 20,\r\n    \"totalPages\" : 0,\r\
+                    \n    \"totalElements\" : 0\r\n  },\r\n  \"error\" : null\r\n}"
+                상품_목록_조회_성공:
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
+                    id\" : 1,\r\n      \"name\" : \"콜드브루\",\r\n      \"price\" : 3500,\r\
+                    \n      \"quantity\" : 100,\r\n      \"thumbnail\" : \"https://test.com/thumbnail.png\"\
+                    ,\r\n      \"detailImage\" : \"https://test.com/detail.png\",\r\
+                    \n      \"intensity\" : \"Strong\",\r\n      \"cupSize\" : \"\
+                    Large\",\r\n      \"isSoldOut\" : false\r\n    }, {\r\n      \"\
+                    id\" : 2,\r\n      \"name\" : \"아메리카노\",\r\n      \"price\" :\
+                    \ 3000,\r\n      \"quantity\" : 150,\r\n      \"thumbnail\" :\
+                    \ \"https://test.com/americano.png\",\r\n      \"detailImage\"\
+                    \ : \"https://test.com/americano-detail.png\",\r\n      \"intensity\"\
+                    \ : \"Medium\",\r\n      \"cupSize\" : \"Small\",\r\n      \"\
+                    isSoldOut\" : false\r\n    } ],\r\n    \"page\" : 0,\r\n    \"\
+                    size\" : 20,\r\n    \"totalPages\" : 1,\r\n    \"totalElements\"\
+                    \ : 2\r\n  },\r\n  \"error\" : null\r\n}"
   /products/categories:
     get:
       tags:
@@ -1336,26 +1109,13 @@ paths:
                 $ref: "#/components/schemas/products-categories466113931"
               examples:
                 카테고리_목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "cupSizes" : [ {
-                          "id" : "1",
-                          "label" : "25ml"
-                        }, {
-                          "id" : "2",
-                          "label" : "80ml"
-                        } ],
-                        "intensities" : [ {
-                          "id" : "3",
-                          "label" : "1"
-                        }, {
-                          "id" : "4",
-                          "label" : "2"
-                        } ]
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"cupSizes\" : [ {\r\n      \"\
+                    id\" : \"1\",\r\n      \"label\" : \"25ml\"\r\n    }, {\r\n  \
+                    \    \"id\" : \"2\",\r\n      \"label\" : \"80ml\"\r\n    } ],\r\
+                    \n    \"intensities\" : [ {\r\n      \"id\" : \"3\",\r\n     \
+                    \ \"label\" : \"1\"\r\n    }, {\r\n      \"id\" : \"4\",\r\n \
+                    \     \"label\" : \"2\"\r\n    } ]\r\n  },\r\n  \"error\" : null\r\
+                    \n}"
   /products/main:
     get:
       tags:
@@ -1371,34 +1131,19 @@ paths:
                 $ref: "#/components/schemas/products-main-996164674"
               examples:
                 메인_상품목록_조회:
-                  value: |-
-                    {
-                      "data" : {
-                        "new" : [ {
-                          "id" : 1,
-                          "name" : "콜드브루",
-                          "price" : 3500,
-                          "quantity" : 100,
-                          "thumbnail" : "https://test.com/thumbnail.png",
-                          "detailImage" : "https://test.com/detail.png",
-                          "intensity" : "Strong",
-                          "cupSize" : "Large",
-                          "isSoldOut" : false
-                        } ],
-                        "best" : [ {
-                          "id" : 1,
-                          "name" : "콜드브루",
-                          "price" : 3500,
-                          "quantity" : 100,
-                          "thumbnail" : "https://test.com/thumbnail.png",
-                          "detailImage" : "https://test.com/detail.png",
-                          "intensity" : "Strong",
-                          "cupSize" : "Large",
-                          "isSoldOut" : false
-                        } ]
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"new\" : [ {\r\n      \"id\"\
+                    \ : 1,\r\n      \"name\" : \"콜드브루\",\r\n      \"price\" : 3500,\r\
+                    \n      \"quantity\" : 100,\r\n      \"thumbnail\" : \"https://test.com/thumbnail.png\"\
+                    ,\r\n      \"detailImage\" : \"https://test.com/detail.png\",\r\
+                    \n      \"intensity\" : \"Strong\",\r\n      \"cupSize\" : \"\
+                    Large\",\r\n      \"isSoldOut\" : false\r\n    } ],\r\n    \"\
+                    best\" : [ {\r\n      \"id\" : 1,\r\n      \"name\" : \"콜드브루\"\
+                    ,\r\n      \"price\" : 3500,\r\n      \"quantity\" : 100,\r\n\
+                    \      \"thumbnail\" : \"https://test.com/thumbnail.png\",\r\n\
+                    \      \"detailImage\" : \"https://test.com/detail.png\",\r\n\
+                    \      \"intensity\" : \"Strong\",\r\n      \"cupSize\" : \"Large\"\
+                    ,\r\n      \"isSoldOut\" : false\r\n    } ]\r\n  },\r\n  \"error\"\
+                    \ : null\r\n}"
   /products/{productId}:
     get:
       tags:
@@ -1424,20 +1169,12 @@ paths:
                 $ref: "#/components/schemas/products-productId-988628468"
               examples:
                 상품_상세_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "id" : 1,
-                        "name" : "콜드브루",
-                        "price" : 3500,
-                        "quantity" : 100,
-                        "thumbnail" : "https://test.com/thumbnail.png",
-                        "detailImage" : "https://test.com/detail.png",
-                        "intensity" : "Strong",
-                        "cupSize" : "Large"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"id\" : 1,\r\n    \"name\" :\
+                    \ \"콜드브루\",\r\n    \"price\" : 3500,\r\n    \"quantity\" : 100,\r\
+                    \n    \"thumbnail\" : \"https://test.com/thumbnail.png\",\r\n\
+                    \    \"detailImage\" : \"https://test.com/detail.png\",\r\n  \
+                    \  \"intensity\" : \"Strong\",\r\n    \"cupSize\" : \"Large\"\r\
+                    \n  },\r\n  \"error\" : null\r\n}"
   /reviews:
     post:
       tags:
@@ -1465,13 +1202,8 @@ paths:
               $ref: "#/components/schemas/reviews1890941445"
             examples:
               리뷰_등록_성공:
-                value: |-
-                  {
-                    "orderNumber" : "ORDER1234",
-                    "orderItemId" : 10,
-                    "rating" : 3,
-                    "content" : "좋습니다."
-                  }
+                value: "{\r\n  \"orderNumber\" : \"ORDER1234\",\r\n  \"orderItemId\"\
+                  \ : 10,\r\n  \"rating\" : 3,\r\n  \"content\" : \"좋습니다.\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -1481,13 +1213,8 @@ paths:
                 $ref: "#/components/schemas/reviews-1411419170"
               examples:
                 리뷰_등록_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "reviewId" : 10
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"reviewId\" : 10\r\n  },\r\n\
+                    \  \"error\" : null\r\n}"
   /reviews/rating:byProduct:
     get:
       tags:
@@ -1510,21 +1237,12 @@ paths:
                 $ref: "#/components/schemas/reviews-rating:byProduct-66572293"
               examples:
                 상품_리뷰별점통계_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "averageRating" : 3.5,
-                        "totalCount" : 10,
-                        "ratingDistribution" : {
-                          "oneStarCount" : 2,
-                          "twoStarsCount" : 3,
-                          "threeStarsCount" : 5,
-                          "fourStarsCount" : 1,
-                          "fiveStarsCount" : 8
-                        }
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"averageRating\" : 3.5,\r\n\
+                    \    \"totalCount\" : 10,\r\n    \"ratingDistribution\" : {\r\n\
+                    \      \"oneStarCount\" : 2,\r\n      \"twoStarsCount\" : 3,\r\
+                    \n      \"threeStarsCount\" : 5,\r\n      \"fourStarsCount\" :\
+                    \ 1,\r\n      \"fiveStarsCount\" : 8\r\n    }\r\n  },\r\n  \"\
+                    error\" : null\r\n}"
   /reviews/{reviewId}:
     put:
       tags:
@@ -1557,11 +1275,7 @@ paths:
               $ref: "#/components/schemas/reviews-reviewId480882763"
             examples:
               리뷰_수정_성공:
-                value: |-
-                  {
-                    "rating" : 3,
-                    "content" : "좋습니다."
-                  }
+                value: "{\r\n  \"rating\" : 3,\r\n  \"content\" : \"좋습니다.\"\r\n}"
       responses:
         "200":
           description: "200"
@@ -1571,13 +1285,8 @@ paths:
                 $ref: "#/components/schemas/reviews-reviewId-215377401"
               examples:
                 리뷰_수정_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "reviewId" : 10
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"reviewId\" : 10\r\n  },\r\n\
+                    \  \"error\" : null\r\n}"
     delete:
       tags:
       - Review
@@ -1606,16 +1315,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 리뷰_삭제_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /reviews:byAuthor:
     get:
       tags:
@@ -1651,30 +1355,16 @@ paths:
                 $ref: "#/components/schemas/reviews:byAuthor2129595722"
               examples:
                 사용자_리뷰목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ {
-                          "reviewId" : 1,
-                          "rating" : 5,
-                          "content" : "아주 만족해요",
-                          "adminReply" : {
-                            "content" : "감사합니다",
-                            "createdAt" : "2025-06-01T12:00"
-                          },
-                          "product" : {
-                            "productId" : 1,
-                            "productName" : "상품"
-                          },
-                          "createdAt" : "2025-06-01T12:00"
-                        } ],
-                        "page" : 1,
-                        "size" : 10,
-                        "totalPages" : 2,
-                        "totalElements" : 11
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
+                    reviewId\" : 1,\r\n      \"rating\" : 5,\r\n      \"content\"\
+                    \ : \"아주 만족해요\",\r\n      \"adminReply\" : {\r\n        \"content\"\
+                    \ : \"감사합니다\",\r\n        \"createdAt\" : \"2025-06-01T12:00\"\
+                    \r\n      },\r\n      \"product\" : {\r\n        \"productId\"\
+                    \ : 1,\r\n        \"productName\" : \"상품\"\r\n      },\r\n   \
+                    \   \"createdAt\" : \"2025-06-01T12:00\"\r\n    } ],\r\n    \"\
+                    page\" : 1,\r\n    \"size\" : 10,\r\n    \"totalPages\" : 2,\r\
+                    \n    \"totalElements\" : 11\r\n  },\r\n  \"error\" : null\r\n\
+                    }"
   /reviews:byProduct:
     get:
       tags:
@@ -1703,26 +1393,14 @@ paths:
                 $ref: "#/components/schemas/reviews:byProduct-352554938"
               examples:
                 상품_리뷰목록_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "content" : [ {
-                          "reviewId" : 1,
-                          "rating" : 5,
-                          "content" : "아주 만족해요",
-                          "createdAt" : "2025-06-01T12:00",
-                          "adminReply" : {
-                            "content" : "감사합니다",
-                            "createdAt" : "2025-06-01T12:00"
-                          }
-                        } ],
-                        "page" : 1,
-                        "size" : 10,
-                        "totalPages" : 2,
-                        "totalElements" : 11
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"content\" : [ {\r\n      \"\
+                    reviewId\" : 1,\r\n      \"rating\" : 5,\r\n      \"content\"\
+                    \ : \"아주 만족해요\",\r\n      \"createdAt\" : \"2025-06-01T12:00\"\
+                    ,\r\n      \"adminReply\" : {\r\n        \"content\" : \"감사합니다\
+                    \",\r\n        \"createdAt\" : \"2025-06-01T12:00\"\r\n      }\r\
+                    \n    } ],\r\n    \"page\" : 1,\r\n    \"size\" : 10,\r\n    \"\
+                    totalPages\" : 2,\r\n    \"totalElements\" : 11\r\n  },\r\n  \"\
+                    error\" : null\r\n}"
   /users/addresses:
     get:
       tags:
@@ -1746,20 +1424,12 @@ paths:
                 $ref: "#/components/schemas/users-addresses1010895288"
               examples:
                 배송지_목록조회_성공:
-                  value: |-
-                    {
-                      "data" : [ {
-                        "addressId" : 1,
-                        "alias" : "집",
-                        "recipientName" : "홍길동",
-                        "recipientPhone" : "010-1234-5678",
-                        "zipCode" : "12345",
-                        "address1" : "서울시 강남구 테헤란로 123",
-                        "address2" : "A동 101호",
-                        "isDefault" : true
-                      } ],
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : [ {\r\n    \"addressId\" : 1,\r\n    \"\
+                    alias\" : \"집\",\r\n    \"recipientName\" : \"홍길동\",\r\n    \"\
+                    recipientPhone\" : \"010-1234-5678\",\r\n    \"zipCode\" : \"\
+                    12345\",\r\n    \"address1\" : \"서울시 강남구 테헤란로 123\",\r\n    \"\
+                    address2\" : \"A동 101호\",\r\n    \"isDefault\" : true\r\n  } ],\r\
+                    \n  \"error\" : null\r\n}"
     post:
       tags:
       - Address
@@ -1780,16 +1450,10 @@ paths:
               $ref: "#/components/schemas/users-addresses135049666"
             examples:
               배송지_등록_성공:
-                value: |-
-                  {
-                    "alias" : "회사",
-                    "recipientName" : "홍길동",
-                    "recipientPhone" : "010-1234-1234",
-                    "zipCode" : "08123",
-                    "address1" : "서울특별시 관악구",
-                    "address2" : "123동 123호",
-                    "isDefault" : true
-                  }
+                value: "{\r\n  \"alias\" : \"회사\",\r\n  \"recipientName\" : \"홍길동\"\
+                  ,\r\n  \"recipientPhone\" : \"010-1234-1234\",\r\n  \"zipCode\"\
+                  \ : \"08123\",\r\n  \"address1\" : \"서울특별시 관악구\",\r\n  \"address2\"\
+                  \ : \"123동 123호\",\r\n  \"isDefault\" : true\r\n}"
       responses:
         "200":
           description: "200"
@@ -1799,13 +1463,8 @@ paths:
                 $ref: "#/components/schemas/users-addresses414680085"
               examples:
                 배송지_등록_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "addressId" : 10
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"addressId\" : 10\r\n  },\r\n\
+                    \  \"error\" : null\r\n}"
   /users/addresses/default:
     get:
       tags:
@@ -1828,33 +1487,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/users-addresses-default772693087"
               examples:
-                기본배송지_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "hasDefault" : true,
-                        "address" : {
-                          "addressId" : 1,
-                          "alias" : "집",
-                          "recipientName" : "홍길동",
-                          "recipientPhone" : "010-1234-5678",
-                          "zipCode" : "12345",
-                          "address1" : "서울시 강남구 테헤란로 123",
-                          "address2" : "A동 101호",
-                          "isDefault" : true
-                        }
-                      },
-                      "error" : null
-                    }
                 기본배송지_없음:
-                  value: |-
-                    {
-                      "data" : {
-                        "hasDefault" : false,
-                        "address" : null
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"hasDefault\" : false,\r\n \
+                    \   \"address\" : null\r\n  },\r\n  \"error\" : null\r\n}"
+                기본배송지_조회_성공:
+                  value: "{\r\n  \"data\" : {\r\n    \"hasDefault\" : true,\r\n  \
+                    \  \"address\" : {\r\n      \"addressId\" : 1,\r\n      \"alias\"\
+                    \ : \"집\",\r\n      \"recipientName\" : \"홍길동\",\r\n      \"recipientPhone\"\
+                    \ : \"010-1234-5678\",\r\n      \"zipCode\" : \"12345\",\r\n \
+                    \     \"address1\" : \"서울시 강남구 테헤란로 123\",\r\n      \"address2\"\
+                    \ : \"A동 101호\",\r\n      \"isDefault\" : true\r\n    }\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /users/addresses/{addressId}:
     put:
       tags:
@@ -1885,16 +1528,10 @@ paths:
               $ref: "#/components/schemas/users-addresses135049666"
             examples:
               배송지_수정_성공:
-                value: |-
-                  {
-                    "alias" : "회사",
-                    "recipientName" : "홍길동",
-                    "recipientPhone" : "010-1234-1234",
-                    "zipCode" : "08123",
-                    "address1" : "서울특별시 관악구",
-                    "address2" : "123동 123호",
-                    "isDefault" : true
-                  }
+                value: "{\r\n  \"alias\" : \"회사\",\r\n  \"recipientName\" : \"홍길동\"\
+                  ,\r\n  \"recipientPhone\" : \"010-1234-1234\",\r\n  \"zipCode\"\
+                  \ : \"08123\",\r\n  \"address1\" : \"서울특별시 관악구\",\r\n  \"address2\"\
+                  \ : \"123동 123호\",\r\n  \"isDefault\" : true\r\n}"
       responses:
         "200":
           description: "200"
@@ -1904,13 +1541,8 @@ paths:
                 $ref: "#/components/schemas/users-addresses414680085"
               examples:
                 배송지_수정_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "addressId" : 10
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"addressId\" : 10\r\n  },\r\n\
+                    \  \"error\" : null\r\n}"
     delete:
       tags:
       - Address
@@ -1939,16 +1571,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/reviews-reviewId1686665306"
+                $ref: "#/components/schemas/payments-cancel1686665306"
               examples:
                 배송지_삭제_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "message" : "OK"
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"message\" : \"OK\"\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
   /users/addresses/{userAddressId}:
     get:
       tags:
@@ -1978,20 +1605,12 @@ paths:
                 $ref: "#/components/schemas/users-addresses-userAddressId133936271"
               examples:
                 배송지_조회_성공:
-                  value: |-
-                    {
-                      "data" : {
-                        "addressId" : 1,
-                        "alias" : "집",
-                        "recipientName" : "홍길동",
-                        "recipientPhone" : "010-1234-5678",
-                        "zipCode" : "12345",
-                        "address1" : "서울시 강남구 테헤란로 123",
-                        "address2" : "A동 101호",
-                        "isDefault" : true
-                      },
-                      "error" : null
-                    }
+                  value: "{\r\n  \"data\" : {\r\n    \"addressId\" : 1,\r\n    \"\
+                    alias\" : \"집\",\r\n    \"recipientName\" : \"홍길동\",\r\n    \"\
+                    recipientPhone\" : \"010-1234-5678\",\r\n    \"zipCode\" : \"\
+                    12345\",\r\n    \"address1\" : \"서울시 강남구 테헤란로 123\",\r\n    \"\
+                    address2\" : \"A동 101호\",\r\n    \"isDefault\" : true\r\n  },\r\
+                    \n  \"error\" : null\r\n}"
 components:
   schemas:
     reviews-1411419170:
@@ -2150,6 +1769,49 @@ components:
             productId:
               type: number
               description: 생성된 상품 아이디
+    admin-products-productId-412506376:
+      type: object
+      properties:
+        data:
+          required:
+          - cupSize
+          - detailImage
+          - id
+          - intensity
+          - name
+          - price
+          - quantity
+          - status
+          - thumbnail
+          type: object
+          properties:
+            intensity:
+              type: string
+              description: 원두 강도
+            thumbnail:
+              type: string
+              description: 썸네일 이미지 URL
+            quantity:
+              type: number
+              description: 재고 수량
+            price:
+              type: number
+              description: 가격
+            name:
+              type: string
+              description: 상품명
+            id:
+              type: number
+              description: 상품 ID
+            cupSize:
+              type: string
+              description: 컵 사이즈
+            status:
+              type: string
+              description: 판매상태
+            detailImage:
+              type: string
+              description: 상세 이미지 URL
     users-addresses-default772693087:
       type: object
       properties:
@@ -2198,50 +1860,7 @@ components:
                   type: number
                   description: 배송지 ID
               description: 기본 배송지
-    admin-products-productId-412506376:
-      type: object
-      properties:
-        data:
-          required:
-          - cupSize
-          - detailImage
-          - id
-          - intensity
-          - name
-          - price
-          - quantity
-          - status
-          - thumbnail
-          type: object
-          properties:
-            intensity:
-              type: string
-              description: 원두 강도
-            thumbnail:
-              type: string
-              description: 썸네일 이미지 URL
-            quantity:
-              type: number
-              description: 재고 수량
-            price:
-              type: number
-              description: 가격
-            name:
-              type: string
-              description: 상품명
-            id:
-              type: number
-              description: 상품 ID
-            cupSize:
-              type: string
-              description: 컵 사이즈
-            status:
-              type: string
-              description: 판매상태
-            detailImage:
-              type: string
-              description: 상세 이미지 URL
-    reviews-reviewId1686665306:
+    payments-cancel1686665306:
       type: object
       properties:
         data:
@@ -2346,6 +1965,8 @@ components:
             detailImage:
               type: string
               description: 상세 이미지 URL
+    orders-orderNumber-cancel486549215:
+      type: object
     cart-items-cartItemId-2049702389:
       required:
       - cartItemId
@@ -2377,6 +1998,14 @@ components:
             key:
               type: string
               description: S3 Object Key
+    payments-cancel-919447853:
+      required:
+      - orderNumber
+      type: object
+      properties:
+        orderNumber:
+          type: string
+          description: 주분번호
     products-main-996164674:
       type: object
       properties:
@@ -2467,50 +2096,6 @@ components:
                   detailImage:
                     type: string
                     description: 상세 이미지 URL
-    admin-products-productId-1789436874:
-      required:
-      - cupSizeId
-      - detailImage
-      - intensityId
-      - name
-      - price
-      - quantity
-      - status
-      - thumbnail
-      type: object
-      properties:
-        thumbnail:
-          type: string
-          description: 썸네일 이미지
-        intensityId:
-          type: number
-          description: 강도 카테고리 아이디
-        quantity:
-          type: number
-          description: 재고 수량
-        price:
-          type: number
-          description: 가격
-        cupSizeId:
-          type: number
-          description: 컵사이즈 카테고리 아이디
-        name:
-          type: string
-          description: 상품명
-        status:
-          type: string
-          description: 판매상태 코드
-        detailImage:
-          type: string
-          description: 상세 이미지
-    payments-refund-919447853:
-      required:
-      - orderNumber
-      type: object
-      properties:
-        orderNumber:
-          type: string
-          description: 주분번호
     admin-reviews1949273614:
       type: object
       properties:
@@ -2591,6 +2176,42 @@ components:
             totalElements:
               type: number
               description: 총 수
+    admin-products-productId-1789436874:
+      required:
+      - cupSizeId
+      - detailImage
+      - intensityId
+      - name
+      - price
+      - quantity
+      - status
+      - thumbnail
+      type: object
+      properties:
+        thumbnail:
+          type: string
+          description: 썸네일 이미지
+        intensityId:
+          type: number
+          description: 강도 카테고리 아이디
+        quantity:
+          type: number
+          description: 재고 수량
+        price:
+          type: number
+          description: 가격
+        cupSizeId:
+          type: number
+          description: 컵사이즈 카테고리 아이디
+        name:
+          type: string
+          description: 상품명
+        status:
+          type: string
+          description: 판매상태 코드
+        detailImage:
+          type: string
+          description: 상세 이미지
     users-addresses414680085:
       type: object
       properties:
@@ -2602,6 +2223,18 @@ components:
             addressId:
               type: number
               description: 배송지 아이디
+    reviews-reviewId480882763:
+      required:
+      - content
+      - rating
+      type: object
+      properties:
+        rating:
+          type: number
+          description: 별점
+        content:
+          type: string
+          description: 리뷰 내용
     orders-2108059589:
       type: object
       properties:
@@ -2663,85 +2296,107 @@ components:
             totalElements:
               type: number
               description: 총 수
-    reviews-reviewId480882763:
-      required:
-      - content
-      - rating
-      type: object
-      properties:
-        rating:
-          type: number
-          description: 별점
-        content:
-          type: string
-          description: 리뷰 내용
-    products-1886796052:
+    orders-prepare1135603467:
       type: object
       properties:
         data:
           required:
-          - content
-          - page
-          - size
-          - totalElements
-          - totalPages
+          - cartItemIds
+          - finalTotalPrice
+          - itemsSubtotal
+          - shippingFee
           type: object
           properties:
-            size:
+            itemsSubtotal:
               type: number
-              description: 페이지 크기
-            totalPages:
+              description: 상품 금액 합계
+            shippingFee:
               type: number
-              description: 전체 페이지 수
-            page:
-              type: number
-              description: 현재 페이지 번호
-            content:
+              description: 배송비
+            cartItemIds:
               type: array
-              description: 상품 목록
+              description: 장바구니 아이템 아이디
+              items:
+                oneOf:
+                - type: object
+                - type: boolean
+                - type: string
+                - type: number
+            finalTotalPrice:
+              type: number
+              description: 최종 결제 금액
+            shippingInfo:
+              required:
+              - address1
+              - addressId
+              - recipientName
+              - recipientPhone
+              - zipCode
+              type: object
+              properties:
+                zipCode:
+                  type: string
+                  description: 우편번호
+                recipientPhone:
+                  type: string
+                  description: 수령인 전화번호
+                address2:
+                  type: string
+                  description: 상세주소
+                  nullable: true
+                address1:
+                  type: string
+                  description: 주소
+                recipientName:
+                  type: string
+                  description: 수령인 이름
+                addressId:
+                  type: number
+                  description: 배송지 아이디
+            paymentMethod:
+              type: array
               items:
                 required:
-                - cupSize
-                - detailImage
-                - id
-                - intensity
-                - isSoldOut
-                - name
-                - price
-                - quantity
-                - thumbnail
+                - code
+                - label
                 type: object
                 properties:
-                  intensity:
+                  code:
                     type: string
-                    description: 원두 강도
+                    description: 결제 수단 코드
+                  label:
+                    type: string
+                    description: 결제 수단 이름
+            items:
+              type: array
+              items:
+                required:
+                - itemSubtotal
+                - name
+                - productId
+                - quantity
+                - thumbnail
+                - unitPrice
+                type: object
+                properties:
+                  itemSubtotal:
+                    type: number
+                    description: 상품 소계
+                  unitPrice:
+                    type: number
+                    description: 상품 단가
                   thumbnail:
                     type: string
-                    description: 썸네일 이미지 URL
+                    description: 상품 썸네일 URL
                   quantity:
                     type: number
-                    description: 재고 수량
-                  price:
+                    description: 수량
+                  productId:
                     type: number
-                    description: 가격
-                  isSoldOut:
-                    type: boolean
-                    description: 품절 여부
+                    description: 상품 ID
                   name:
                     type: string
                     description: 상품명
-                  id:
-                    type: number
-                    description: 상품 ID
-                  cupSize:
-                    type: string
-                    description: 컵 사이즈
-                  detailImage:
-                    type: string
-                    description: 상세 이미지 URL
-            totalElements:
-              type: number
-              description: 총 상품 수
     reviews:byAuthor2129595722:
       type: object
       properties:
@@ -2810,6 +2465,73 @@ components:
             totalElements:
               type: number
               description: 총 수
+    products-1886796052:
+      type: object
+      properties:
+        data:
+          required:
+          - content
+          - page
+          - size
+          - totalElements
+          - totalPages
+          type: object
+          properties:
+            size:
+              type: number
+              description: 페이지 크기
+            totalPages:
+              type: number
+              description: 전체 페이지 수
+            page:
+              type: number
+              description: 현재 페이지 번호
+            content:
+              type: array
+              description: 상품 목록
+              items:
+                required:
+                - cupSize
+                - detailImage
+                - id
+                - intensity
+                - isSoldOut
+                - name
+                - price
+                - quantity
+                - thumbnail
+                type: object
+                properties:
+                  intensity:
+                    type: string
+                    description: 원두 강도
+                  thumbnail:
+                    type: string
+                    description: 썸네일 이미지 URL
+                  quantity:
+                    type: number
+                    description: 재고 수량
+                  price:
+                    type: number
+                    description: 가격
+                  isSoldOut:
+                    type: boolean
+                    description: 품절 여부
+                  name:
+                    type: string
+                    description: 상품명
+                  id:
+                    type: number
+                    description: 상품 ID
+                  cupSize:
+                    type: string
+                    description: 컵 사이즈
+                  detailImage:
+                    type: string
+                    description: 상세 이미지 URL
+            totalElements:
+              type: number
+              description: 총 상품 수
     orders-orderNumber1806927897:
       type: object
       properties:
@@ -3220,6 +2942,18 @@ components:
             stockQuantity:
               type: number
               description: 재고 수량
+    payments808279509:
+      required:
+      - orderNumber
+      - transactionId
+      type: object
+      properties:
+        orderNumber:
+          type: string
+          description: 주분번호
+        transactionId:
+          type: string
+          description: PG사 결제 아이디
     admin-products-selling-status-152159338:
       type: object
       properties:
@@ -3237,18 +2971,6 @@ components:
               label:
                 type: string
                 description: 판매상태
-    payments808279509:
-      required:
-      - orderNumber
-      - transactionId
-      type: object
-      properties:
-        orderNumber:
-          type: string
-          description: 주분번호
-        transactionId:
-          type: string
-          description: PG사 결제 아이디
     users-addresses1010895288:
       type: object
       properties:
@@ -3369,103 +3091,6 @@ components:
             productId:
               type: number
               description: 수정된 상품 아이디
-    orders-prepare-1188466473:
-      type: object
-      properties:
-        data:
-          required:
-          - cartItemIds
-          - finalTotalPrice
-          - itemsSubtotal
-          - shippingFee
-          type: object
-          properties:
-            itemsSubtotal:
-              type: number
-              description: 상품 금액 합계
-            shippingFee:
-              type: number
-              description: 배송비
-            cartItemIds:
-              type: array
-              description: 장바구니 아이템 아이디
-              items:
-                oneOf:
-                - type: object
-                - type: boolean
-                - type: string
-                - type: number
-            finalTotalPrice:
-              type: number
-              description: 최종 결제 금액
-            shippingInfo:
-              required:
-              - address1
-              - recipientName
-              - recipientPhone
-              - zipCode
-              type: object
-              properties:
-                zipCode:
-                  type: string
-                  description: 우편번호
-                recipientPhone:
-                  type: string
-                  description: 수령인 전화번호
-                address2:
-                  type: string
-                  description: 상세주소
-                  nullable: true
-                address1:
-                  type: string
-                  description: 주소
-                recipientName:
-                  type: string
-                  description: 수령인 이름
-            paymentMethod:
-              type: array
-              items:
-                required:
-                - code
-                - label
-                type: object
-                properties:
-                  code:
-                    type: string
-                    description: 결제 수단 코드
-                  label:
-                    type: string
-                    description: 결제 수단 이름
-            items:
-              type: array
-              items:
-                required:
-                - itemSubtotal
-                - name
-                - productId
-                - quantity
-                - thumbnail
-                - unitPrice
-                type: object
-                properties:
-                  itemSubtotal:
-                    type: number
-                    description: 상품 소계
-                  unitPrice:
-                    type: number
-                    description: 상품 단가
-                  thumbnail:
-                    type: string
-                    description: 상품 썸네일 URL
-                  quantity:
-                    type: number
-                    description: 수량
-                  productId:
-                    type: number
-                    description: 상품 ID
-                  name:
-                    type: string
-                    description: 상품명
     admin-reviews-reply-replyId1254049025:
       type: object
       properties:

--- a/src/test/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/resolver/RoleBasedUserArgumentResolverTest.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/resolver/RoleBasedUserArgumentResolverTest.kt
@@ -1,10 +1,12 @@
 package com.fastcampus.commerce.auth.interfaces.web.security.resolver
 
+import com.fastcampus.commerce.config.TestConfig
 import com.fastcampus.commerce.user.api.service.UserService
 import com.fastcampus.commerce.user.domain.entity.User
 import com.fastcampus.commerce.user.domain.enums.UserRole
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -19,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(controllers = [SampleController::class])
-@Import(RoleBasedUserArgumentResolver::class, RoleBasedUserArgumentResolverTest.MockConfig::class)
+@Import(RoleBasedUserArgumentResolver::class, TestConfig::class)
 class RoleBasedUserArgumentResolverTest {
 
     @Autowired
@@ -27,13 +29,6 @@ class RoleBasedUserArgumentResolverTest {
 
     @Autowired
     lateinit var userService: UserService
-
-    @TestConfiguration
-    class MockConfig {
-        @Bean
-        @Primary
-        fun userService(): UserService = mockk(relaxed = true)
-    }
 
     @Test
     fun `권한이 맞을 때는 User가 주입된다`() {

--- a/src/test/kotlin/com/fastcampus/commerce/config/TestConfig.kt
+++ b/src/test/kotlin/com/fastcampus/commerce/config/TestConfig.kt
@@ -1,13 +1,23 @@
 package com.fastcampus.commerce.config
 
+import com.fastcampus.commerce.auth.interfaces.web.security.resolver.RoleBasedUserArgumentResolver
 import com.fastcampus.commerce.common.resolver.PageableProperties
+import com.fastcampus.commerce.user.api.service.UserService
+import com.fastcampus.commerce.user.domain.entity.User
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import io.mockk.every
+import io.mockk.mockk
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.core.MethodParameter
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.ModelAndViewContainer
 import java.time.format.DateTimeFormatter
 
 @TestConfiguration
@@ -34,5 +44,29 @@ class TestConfig {
     fun jackson2ObjectMapperBuilder(): Jackson2ObjectMapperBuilder {
         return Jackson2ObjectMapperBuilder()
             .serializers(LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")))
+    }
+
+    @Primary
+    @Bean
+    fun mockUserService(): UserService {
+        return mockk<UserService>()
+    }
+
+    @Primary
+    @Bean
+    fun testRoleBasedUserArgumentResolver(userService: UserService): RoleBasedUserArgumentResolver {
+        return object : RoleBasedUserArgumentResolver(userService) {
+            override fun resolveArgument(
+                parameter: MethodParameter,
+                mavContainer: ModelAndViewContainer?,
+                webRequest: NativeWebRequest,
+                binderFactory: WebDataBinderFactory?
+            ): Any? {
+                return mockk<User> {
+                    every { id } returns 1L
+                    every { name } returns "testUser"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #89 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->