### PR TITLE
Feat/88 admin order

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/application/AdminOrderService.kt
@@ -1,0 +1,17 @@
+package com.fastcampus.commerce.admin.order.application
+
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderSearchRequest
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderListResponse
+import com.fastcampus.commerce.admin.order.interfaces.AdminOrderQuery
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+
+@Service
+class AdminOrderService(
+    private val adminOrderQuery: AdminOrderQuery
+) {
+    fun getOrders(request: AdminOrderSearchRequest, pageable: Pageable): Page<AdminOrderListResponse> {
+        return adminOrderQuery.searchOrders(request, pageable, pageable.sort)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/application/AdminOrderService.kt
@@ -81,6 +81,7 @@ class AdminOrderService(
         )
     }
 
+    //주문 생성
     @Transactional
     fun createOrder(request: AdminOrderCreateRequest): AdminOrderCreateResponse {
         // 1. 주문상품 정보/가격 검증
@@ -124,8 +125,7 @@ class AdminOrderService(
         )
     }
 
-
-
+    //주문 취소
     @Transactional
     fun cancelOrder(orderId: Long) {
         val order = orderRepository.findById(orderId)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/application/AdminOrderService.kt
@@ -1,17 +1,158 @@
 package com.fastcampus.commerce.admin.order.application
 
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderCreateRequest
 import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderSearchRequest
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderUpdateRequest
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderCreateResponse
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderDetailItemResponse
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderDetailResponse
 import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderListResponse
 import com.fastcampus.commerce.admin.order.interfaces.AdminOrderQuery
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.order.application.query.ProductSnapshotReader
+import com.fastcampus.commerce.order.domain.entity.Order
+import com.fastcampus.commerce.order.domain.entity.OrderItem
+import com.fastcampus.commerce.order.domain.entity.OrderStatus
+import com.fastcampus.commerce.order.domain.error.OrderErrorCode
+import com.fastcampus.commerce.order.domain.repository.OrderItemRepository
+import com.fastcampus.commerce.order.domain.repository.OrderRepository
+import com.fastcampus.commerce.order.domain.service.OrderNumberGenerator
+import com.fastcampus.commerce.order.infrastructure.repository.ProductSnapshotRepository
+import com.fastcampus.commerce.payment.domain.repository.PaymentRepository
+import com.fastcampus.commerce.payment.domain.service.PaymentReader
+import com.fastcampus.commerce.user.domain.repository.UserRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class AdminOrderService(
-    private val adminOrderQuery: AdminOrderQuery
+    private val adminOrderQuery: AdminOrderQuery,
+    private val productSnapshotReader: ProductSnapshotReader,
+    private val orderNumberGenerator: OrderNumberGenerator,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val userRepository: UserRepository,
+    private val productSnapshotRepository: ProductSnapshotRepository,
+    private val paymentReader: PaymentReader
 ) {
+    // 주문 조회
     fun getOrders(request: AdminOrderSearchRequest, pageable: Pageable): Page<AdminOrderListResponse> {
         return adminOrderQuery.searchOrders(request, pageable, pageable.sort)
+    }
+
+    // 주문 상세 조회
+    @Transactional(readOnly = true)
+    fun getOrderDetail(orderId: Long): AdminOrderDetailResponse {
+        val order = orderRepository.findById(orderId)
+            .orElseThrow { CoreException(OrderErrorCode.ORDER_NOT_FOUND) }
+        val user = userRepository.findById(order.userId)
+            .orElse(null)
+        val payment = paymentReader.getByOrderId(order.id!!)
+
+        val items = orderItemRepository.findByOrderId(order.id!!).map { orderItem ->
+            val productSnapshot = productSnapshotRepository.findById(orderItem.productSnapshotId!!).get()
+            AdminOrderDetailItemResponse(
+                productName = productSnapshot.name,
+                quantity = orderItem.quantity,
+                price = orderItem.unitPrice,
+                total = orderItem.unitPrice * orderItem.quantity,
+                thumbnail = productSnapshot.thumbnail,
+            )
+        }
+
+        val subtotal = items.sumOf { it.total }
+
+        return AdminOrderDetailResponse(
+            orderNumber = order.orderNumber,
+            status = order.status.name,
+            createdAt = order.createdAt,
+            paymentMethod = payment.paymentMethod.label,
+            address = listOfNotNull(order.address1, order.address2).joinToString(" "),
+            recipientName = order.recipientName,
+            recipientPhone = order.recipientPhone,
+            customerName = user?.name ?: "",
+            customerEmail = user?.email ?: "",
+            items = items,
+            subtotal = subtotal,
+            total = order.totalAmount,
+        )
+    }
+
+    @Transactional
+    fun createOrder(request: AdminOrderCreateRequest): AdminOrderCreateResponse {
+        // 1. 주문상품 정보/가격 검증
+        val orderItems = request.orderItems.map { itemReq ->
+            val productSnapshot = productSnapshotReader.getById(itemReq.productSnapshotId)
+            OrderItem(
+                orderId = 0L, // 나중에 갱신
+                productSnapshotId = itemReq.productSnapshotId,
+                quantity = itemReq.quantity,
+                unitPrice = productSnapshot.price
+            )
+        }
+        val totalAmount = orderItems.sumOf { it.unitPrice * it.quantity }
+
+        // 2. 주문 엔티티 생성/저장
+        val order = Order(
+            orderNumber = orderNumberGenerator.generate(1L),
+            userId = request.userId,
+            totalAmount = totalAmount,
+            recipientName = request.recipientName,
+            recipientPhone = request.recipientPhone,
+            zipCode = request.zipCode,
+            address1 = request.address1,
+            address2 = request.address2,
+            deliveryMessage = request.deliveryMessage,
+            status = OrderStatus.WAITING_FOR_PAYMENT
+        )
+        orderRepository.save(order)
+
+        // 3. 주문상품(OrderItem) 저장
+        orderItems.forEach { it.orderId = order.id!! }
+        orderItemRepository.saveAll(orderItems)
+
+        // 4. 응답 반환
+        return AdminOrderCreateResponse(
+            orderId = order.id!!,
+            orderNumber = order.orderNumber,
+            totalAmount = order.totalAmount,
+            orderStatus = order.status.name,
+            orderedAt = order.createdAt
+        )
+    }
+
+
+
+    @Transactional
+    fun cancelOrder(orderId: Long) {
+        val order = orderRepository.findById(orderId)
+            .orElseThrow { CoreException(OrderErrorCode.ORDER_NOT_FOUND) }
+
+        // 비즈니스 정책: 이미 배송된 주문은 취소 불가 등
+        if (!order.status.isCancellable()) {
+            throw CoreException(OrderErrorCode.ORDER_CANNOT_BE_CANCELLED)
+        }
+
+        order.cancel(cancelledAt = LocalDateTime.now())
+    }
+
+    //주문 수정
+    @Transactional
+    fun updateOrder(orderId: Long, request: AdminOrderUpdateRequest) {
+        val order = orderRepository.findById(orderId)
+            .orElseThrow { CoreException(OrderErrorCode.ORDER_NOT_FOUND) }
+
+        // 필드별로 변경 요청이 있으면 값 변경
+        request.recipientName?.let { order.recipientName = it }
+        request.recipientPhone?.let { order.recipientPhone = it }
+        request.zipCode?.let { order.zipCode = it }
+        request.address1?.let { order.address1 = it }
+        request.address2?.let { order.address2 = it }
+        request.deliveryMessage?.let { order.deliveryMessage = it }
+
+        // 업데이트는 엔티티 dirty checking + @Transactional로 자동 반영
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/controller/AdminOrderController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/controller/AdminOrderController.kt
@@ -1,14 +1,23 @@
 package com.fastcampus.commerce.admin.order.infrastructure.controller
 
 import com.fastcampus.commerce.admin.order.application.AdminOrderService
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderCreateRequest
 import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderSearchRequest
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderUpdateRequest
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderCreateResponse
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderDetailResponse
 import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderListResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -17,11 +26,39 @@ import org.springframework.web.bind.annotation.RestController
 class AdminOrderController(
     private val adminOrderService: AdminOrderService
 ) {
+    // 주문 조회
     @GetMapping
     fun getOrders(
         @ModelAttribute search: AdminOrderSearchRequest,
         @PageableDefault(size = 20, sort = ["orderDate"], direction = Sort.Direction.DESC) pageable: Pageable
     ): Page<AdminOrderListResponse> {
         return adminOrderService.getOrders(search, pageable)
+    }
+
+    //주문 상세 조회
+    @GetMapping("/{orderId}")
+    fun getOrderDetail(@PathVariable orderId: Long): AdminOrderDetailResponse {
+        return adminOrderService.getOrderDetail(orderId)
+    }
+
+    // 주문 생성
+    @PostMapping
+    fun createOrder(@RequestBody request: AdminOrderCreateRequest): AdminOrderCreateResponse {
+        return adminOrderService.createOrder(request)
+    }
+
+    //주문 취소
+    @DeleteMapping("/{orderId}/cancel")
+    fun cancelOrder(@PathVariable orderId: Long) {
+        adminOrderService.cancelOrder(orderId)
+    }
+
+    //주문 수정
+    @PatchMapping("/{orderId}")
+    fun updateOrder(
+        @PathVariable orderId: Long,
+        @RequestBody request: AdminOrderUpdateRequest
+    ) {
+        adminOrderService.updateOrder(orderId, request)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/controller/AdminOrderController.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/controller/AdminOrderController.kt
@@ -1,0 +1,27 @@
+package com.fastcampus.commerce.admin.order.infrastructure.controller
+
+import com.fastcampus.commerce.admin.order.application.AdminOrderService
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderSearchRequest
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderListResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/admin/orders")
+class AdminOrderController(
+    private val adminOrderService: AdminOrderService
+) {
+    @GetMapping
+    fun getOrders(
+        @ModelAttribute search: AdminOrderSearchRequest,
+        @PageableDefault(size = 20, sort = ["orderDate"], direction = Sort.Direction.DESC) pageable: Pageable
+    ): Page<AdminOrderListResponse> {
+        return adminOrderService.getOrders(search, pageable)
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/request/AdminOrderCreateRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/request/AdminOrderCreateRequest.kt
@@ -1,0 +1,19 @@
+package com.fastcampus.commerce.admin.order.infrastructure.request
+
+import com.fastcampus.commerce.payment.domain.entity.PaymentStatus
+
+data class AdminOrderCreateRequest(
+    val userId: Long, // 주문자 회원ID
+    val orderItems: List<OrderItemRequest>,
+    val recipientName: String,
+    val recipientPhone: String,
+    val zipCode: String,
+    val address1: String,
+    val address2: String?,
+    val deliveryMessage: String?,
+    val paymentMethod: PaymentStatus
+)
+data class OrderItemRequest(
+    val productSnapshotId: Long,
+    val quantity: Int,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/request/AdminOrderSearchRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/request/AdminOrderSearchRequest.kt
@@ -1,0 +1,10 @@
+package com.fastcampus.commerce.admin.order.infrastructure.request
+
+import java.time.LocalDate
+
+data class AdminOrderSearchRequest (
+    val keyword: String? = null,             // 주문번호, 고객명, 상품명 등 검색
+    val status: String? = null,              // 주문 상태 필터링
+    val dateFrom: LocalDate? = null,         // 시작일
+    val dateTo: LocalDate? = null,           // 종료일
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/request/AdminOrderUpdateRequest.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/request/AdminOrderUpdateRequest.kt
@@ -1,0 +1,11 @@
+package com.fastcampus.commerce.admin.order.infrastructure.request
+
+data class AdminOrderUpdateRequest(
+    val recipientName: String?,
+    val recipientPhone: String?,
+    val zipCode: String?,
+    val address1: String?,
+    val address2: String?,
+    val deliveryMessage: String?,
+    val adminMemo: String?
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderCreateResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderCreateResponse.kt
@@ -1,0 +1,11 @@
+package com.fastcampus.commerce.admin.order.infrastructure.response
+
+import java.time.LocalDateTime
+
+data class AdminOrderCreateResponse(
+    val orderId: Long,
+    val orderNumber: String,
+    val totalAmount: Int,
+    val orderStatus: String,
+    val orderedAt: LocalDateTime
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderDetailResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderDetailResponse.kt
@@ -1,0 +1,25 @@
+package com.fastcampus.commerce.admin.order.infrastructure.response
+
+import java.time.LocalDateTime
+
+data class AdminOrderDetailResponse(
+    val orderNumber: String,
+    val status: String,
+    val createdAt: LocalDateTime,
+    val paymentMethod: String,
+    val address: String,
+    val recipientName: String,
+    val recipientPhone: String,
+    val customerName: String,
+    val customerEmail: String,
+    val items: List<AdminOrderDetailItemResponse>,
+    val subtotal: Int,
+    val total: Int,
+)
+data class AdminOrderDetailItemResponse(
+    val productName: String,
+    val quantity: Int,
+    val price: Int,
+    val total: Int,
+    val thumbnail: String?,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderListResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderListResponse.kt
@@ -6,11 +6,11 @@ data class AdminOrderListResponse (
     val orderId: Long,
     val orderNumber: String,
     val productName: String,
-    val productQuantity: String,
-    val productUnitPrice: String,
+    val productQuantity: Int,
+    val productUnitPrice: Int,
     val orderDate: LocalDateTime,
     val customerName: String,
-    val totalAmount: Long,
+    val totalAmount: Int,
     val paymentDate: LocalDateTime?,
     val status: String
 )

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderListResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderListResponse.kt
@@ -5,7 +5,9 @@ import java.time.LocalDateTime
 data class AdminOrderListResponse (
     val orderId: Long,
     val orderNumber: String,
-    val productSummary: String,
+    val productName: String,
+    val productQuantity: String,
+    val productUnitPrice: String,
     val orderDate: LocalDateTime,
     val customerName: String,
     val totalAmount: Long,

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderListResponse.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/infrastructure/response/AdminOrderListResponse.kt
@@ -1,0 +1,14 @@
+package com.fastcampus.commerce.admin.order.infrastructure.response
+
+import java.time.LocalDateTime
+
+data class AdminOrderListResponse (
+    val orderId: Long,
+    val orderNumber: String,
+    val productSummary: String,
+    val orderDate: LocalDateTime,
+    val customerName: String,
+    val totalAmount: Long,
+    val paymentDate: LocalDateTime?,
+    val status: String
+)

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/interfaces/AdminOrderQuery.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/interfaces/AdminOrderQuery.kt
@@ -1,0 +1,15 @@
+package com.fastcampus.commerce.admin.order.interfaces
+
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderSearchRequest
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderListResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+
+interface AdminOrderQuery {
+    fun searchOrders(
+        search: AdminOrderSearchRequest,
+        pageable: Pageable,
+        sort: Sort
+    ): Page<AdminOrderListResponse>
+}

--- a/src/main/kotlin/com/fastcampus/commerce/admin/order/interfaces/AdminOrderQueryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/admin/order/interfaces/AdminOrderQueryImpl.kt
@@ -1,0 +1,104 @@
+package com.fastcampus.commerce.admin.order.interfaces
+
+import com.fastcampus.commerce.admin.order.infrastructure.request.AdminOrderSearchRequest
+import com.fastcampus.commerce.admin.order.infrastructure.response.AdminOrderListResponse
+import com.fastcampus.commerce.order.domain.entity.OrderStatus
+import com.fastcampus.commerce.order.domain.entity.QOrder
+import com.fastcampus.commerce.order.domain.entity.QOrderItem
+import com.fastcampus.commerce.order.domain.entity.QProductSnapshot
+import com.fastcampus.commerce.user.domain.entity.QUser
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Repository
+
+@Repository
+class AdminOrderQueryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : AdminOrderQuery {
+    override fun searchOrders(
+        search: AdminOrderSearchRequest,
+        pageable: Pageable,
+        sort: Sort
+    ): Page<AdminOrderListResponse> {
+        /*val qOrder = QOrder.order
+        val qUser = QUser.user
+        val qOrderItem = QOrderItem.orderItem
+        val qProductSnapshot = QProductSnapshot.productSnapshot
+
+        val query = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    AdminOrderListResponse::class.java,
+                    qOrder.id,
+                    qOrder.orderNumber,
+                    qOrderItem.name, // 요약 or 상품명/수량 등
+                    qOrder.createdAt,
+                    qUser.name,
+                    qOrder.finalTotalPrice,
+                    qOrder.paidAt,
+                    qOrder.status.stringValue()
+                )
+            )
+            .from(qOrder)
+            .leftJoin(qUser).on(qOrder.userId.eq(qUser.id))
+            .leftJoin(qOrderItem).on(qOrder.id.eq(qOrderItem.orderId))
+        // 필요에 따라 ProductSnapshot 등 추가 조인
+
+        // --- 동적 where ---
+        val conditions = mutableListOf<BooleanExpression>()
+        search.keyword?.let { keyword ->
+            conditions.add(
+                qOrder.orderNumber.containsIgnoreCase(keyword)
+                    .or(qUser.name.containsIgnoreCase(keyword))
+                    .or(qOrderItem.name.containsIgnoreCase(keyword))
+            )
+        }
+        search.status?.let { status ->
+            conditions.add(qOrder.status.eq(OrderStatus.valueOf(status)))
+        }
+        search.dateFrom?.let { from ->
+            conditions.add(qOrder.createdAt.goe(from.atStartOfDay()))
+        }
+        search.dateTo?.let { to ->
+            conditions.add(qOrder.createdAt.lt(to.plusDays(1).atStartOfDay()))
+        }
+
+        if (conditions.isNotEmpty()) {
+            query.where(*conditions.toTypedArray())
+        }
+
+        // --- 동적 정렬 (컬럼별 order by) ---
+        if (sort.isSorted) {
+            sort.forEach {
+                val path = when (it.property) {
+                    "orderNumber" -> qOrder.orderNumber
+                    "orderDate" -> qOrder.createdAt
+                    "customerName" -> qUser.name
+                    "totalAmount" -> qOrder.finalTotalPrice
+                    "status" -> qOrder.status
+                    else -> qOrder.id
+                }
+                query.orderBy(
+                    if (it.isAscending) path.asc() else path.desc()
+                )
+            }
+        } else {
+            query.orderBy(qOrder.id.desc())
+        }
+
+        // --- 페이징 ---
+        query.offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+
+        val results = query.fetch()
+        val count = query.fetchCount()
+
+        return PageImpl(results, pageable, count)*/
+        return PageImpl(emptyList())
+    }
+}

--- a/src/main/kotlin/com/fastcampus/commerce/order/application/order/OrderService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/application/order/OrderService.kt
@@ -76,8 +76,7 @@ class OrderService(
         val finalTotalPrice = itemsSubtotal + shippingFee
 
         // 4. 배송지/결제수단 정보
-        val defaultAddress = userAddressService.findDefaultUserAddress(userId)
-            ?: throw IllegalStateException("기본 배송지가 없습니다.") // 도메인에 맞는 에러 처리로 변경 가능
+        val defaultAddress = userAddressService.findDefaultUserAddress(userId)!!
 
         val shippingInfo = PrepareOrderShippingInfoApiResponse(
             recipientName = defaultAddress.recipientName,

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/entity/OrderItem.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/entity/OrderItem.kt
@@ -17,7 +17,7 @@ import jakarta.persistence.Table
 @Entity
 class OrderItem(
     @Column(name = "order_id", nullable = false)
-    val orderId: Long,
+    var orderId: Long,
     @JoinColumn(name = "product_snapshot_id", nullable = false)
     val productSnapshotId: Long,
     @Column(nullable = false)

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/entity/OrderStatus.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/entity/OrderStatus.kt
@@ -12,6 +12,6 @@ enum class OrderStatus {
     ;
 
     fun isCancellable(): Boolean {
-        return this == PAID || this == SHIPPED
+        return this == PAID || this == SHIPPED || this == DELIVERED || this == WAITING_FOR_PAYMENT
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/error/OrderErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/error/OrderErrorCode.kt
@@ -17,4 +17,5 @@ enum class OrderErrorCode(
     UNAUTHORIZED_ORDER_REFUND("ORD-104", "다른 사람의 결제를 환불할 수 없습니다.", LogLevel.WARN),
     NOT_REFUND_REQUESTED_APPROVE("ORD-104", "환불요청한 주문만 환불가능합니다.", LogLevel.WARN),
     NOT_REFUND_REQUESTED_REJECT("ORD-105", "환불요청한 주문만 환불거절 가능합니다.", LogLevel.WARN),
+    ORDER_CANNOT_BE_CANCELLED("ORD-106", "해당 주문은 관리자에 의해 취소할 수 없는 상태입니다.", LogLevel.WARN),
 }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->
- 어드민에서 사용할 주문 기능 구현

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->
- 어드민에서 사용할 주문 기능 구현

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->
- 주문 조회 구현
- 주문 조회 상세 구현
- 주문 요청 구현
- 주문 취소 구현
- 주문 수정

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->

---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->