### PR TITLE
[feat] 결제완료시 재고 차감 로직 추가

### DIFF
--- a/src/main/kotlin/com/fastcampus/commerce/order/application/OrderPaymentService.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/application/OrderPaymentService.kt
@@ -2,7 +2,9 @@ package com.fastcampus.commerce.order.application
 
 import com.fastcampus.commerce.common.error.CoreException
 import com.fastcampus.commerce.order.domain.entity.Order
+import com.fastcampus.commerce.order.domain.entity.OrderItem
 import com.fastcampus.commerce.order.domain.error.OrderErrorCode
+import com.fastcampus.commerce.order.domain.model.OrderProduct
 import com.fastcampus.commerce.order.domain.repository.OrderPaymentRepository
 import org.springframework.stereotype.Service
 
@@ -18,5 +20,9 @@ class OrderPaymentService(
     fun getOrderByOrderId(orderId: Long): Order {
         return orderPaymentRepository.findOrderById(orderId)
             .orElseThrow { CoreException(OrderErrorCode.ORDER_NOT_FOUND) }
+    }
+
+    fun getOrderProducts(orderId: Long):List<OrderProduct> {
+        return orderPaymentRepository.getOrderProducts(orderId)
     }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/entity/Order.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/entity/Order.kt
@@ -110,4 +110,9 @@ class Order(
         this.refundRejectedAt = rejectedAt
         this.status = OrderStatus.REFUND_REJECTED
     }
+
+    fun fail(failedAt: LocalDateTime) {
+        this.cancelledAt = failedAt
+        this.status = OrderStatus.CANCELLED
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/model/OrderProduct.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/model/OrderProduct.kt
@@ -1,0 +1,7 @@
+package com.fastcampus.commerce.order.domain.model
+
+data class OrderProduct (
+    val orderItemId: Long,
+    val productId: Long,
+    val quantity: Int,
+)

--- a/src/main/kotlin/com/fastcampus/commerce/order/domain/repository/OrderPaymentRepository.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/domain/repository/OrderPaymentRepository.kt
@@ -1,10 +1,14 @@
 package com.fastcampus.commerce.order.domain.repository
 
 import com.fastcampus.commerce.order.domain.entity.Order
+import com.fastcampus.commerce.order.domain.entity.OrderItem
+import com.fastcampus.commerce.order.domain.model.OrderProduct
 import java.util.Optional
 
 interface OrderPaymentRepository {
     fun findOrderByOrderNumber(orderNumber: String): Optional<Order>
 
     fun findOrderById(orderId: Long): Optional<Order>
+
+    fun getOrderProducts(orderId: Long): List<OrderProduct>
 }

--- a/src/main/kotlin/com/fastcampus/commerce/order/infrastructure/OrderPaymentRepositoryImpl.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/order/infrastructure/OrderPaymentRepositoryImpl.kt
@@ -45,7 +45,7 @@ class OrderPaymentRepositoryImpl(
                 )
             )
             .from(order)
-            .join(orderItem).on(order.id.eq(orderItem.id))
+            .join(orderItem).on(order.id.eq(orderItem.orderId))
             .join(productSnapshot).on(productSnapshot.id.eq(orderItem.productSnapshotId))
             .where(order.id.eq(orderId))
             .fetch()

--- a/src/main/kotlin/com/fastcampus/commerce/payment/domain/entity/Payment.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/payment/domain/entity/Payment.kt
@@ -71,4 +71,11 @@ class Payment(
             updatedAt = refundAt
         }
     }
+
+    fun fail(failedAt: LocalDateTime, failedReason: String) {
+        if (this.status == PaymentStatus.COMPLETED || this.status == PaymentStatus.WAITING) {
+            status = PaymentStatus.FAILED
+            updatedAt = failedAt
+        }
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/payment/domain/entity/PaymentStatus.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/payment/domain/entity/PaymentStatus.kt
@@ -5,4 +5,5 @@ enum class PaymentStatus {
     COMPLETED,
     CANCELLED,
     REFUNDED,
+    FAILED,
 }

--- a/src/main/kotlin/com/fastcampus/commerce/payment/domain/error/PaymentErrorCode.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/payment/domain/error/PaymentErrorCode.kt
@@ -15,4 +15,5 @@ enum class PaymentErrorCode(
     PG_RESULT_NOT_MATCH_PAYMENT("PAY-005", "결제금액이 일치하지 않습니다.", LogLevel.WARN),
     TRANSACTION_ID_EMPTY("PAY-006", "PG사 결제 아이디가 누락되었습니다.", LogLevel.WARN),
     INVALID_PAYMENT_METHOD("PAY-007", "유효하지 않은 결제방식입니다.", LogLevel.WARN),
+    QUANTITY_NOT_ENOUGH("PAY-008", "재고가 부족해 결제에 실패했습니다.", LogLevel.WARN),
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Inventory.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/entity/Inventory.kt
@@ -46,4 +46,9 @@ class Inventory(
         this.quantity = quantity
         validate()
     }
+
+    fun decreaseQuantity(quantity: Int) {
+        this.quantity -= quantity
+        validate()
+    }
 }

--- a/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
+++ b/src/main/kotlin/com/fastcampus/commerce/product/domain/service/ProductStore.kt
@@ -42,4 +42,9 @@ class ProductStore(
         val inventory = productReader.getInventoryByProductId(productId)
         inventoryRepository.delete(inventory)
     }
+
+    fun decreaseQuantityByProductId(productId: Long, quantity: Int) {
+        val inventory = productReader.getInventoryByProductId(productId)
+        inventory.decreaseQuantity(quantity)
+    }
 }


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
<!-- 이 PR이 왜 필요한지 한 줄로 
- e.g. 로그인 API 구현을 위한 백엔드 로직 추가-->

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->

---

## ⚙️ 구현 상세 (How)
<!-- 구현 중 고민한 점, 선택한 방식, 예외 처리 등
- e.g.
- 기존 세션 로그인과 병렬 구조 유지
- 실패 시 HTTP 401 반환 + 에러 메시지 통일 (`ErrorResponse`)
- `UserService`에서 비밀번호 검증 책임 분리-->

---

## ✅ 테스트 내역
<!-- 검증 방법을 구체적으로 작성해주세요
- 단위 테스트, 수동 테스트, QA 확인 여부 등
- 테스트 못했으면 못한 이유라도 작성해주세요
- e.g.
- [x] 단위 테스트: `LoginServiceTest`
- [x] 수동 테스트: Postman으로 로그인 확인
- [ ] QA 환경 E2E 테스트 예정(24일 예정)-->

- [ ] 

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->
closes #102 
---

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분
- e.g.
- 에러 핸들링 방식 괜찮은지
- `JwtTokenProvider` 네이밍 및 책임 적절한지-->

---

## 📎 기타 참고
<!-- Optional. 내용 없으면 항목 자체를 삭제해주세요 
- 문서, 레퍼런스, 관련 PR, 논의 링크 등 
- [JWT 사양](https://jwt.io)
- `ErrorResponse` 포맷은 #29 참고-->